### PR TITLE
[LFXV2-535] fix: image name

### DIFF
--- a/charts/lfx-v2-auth-service/Chart.yaml
+++ b/charts/lfx-v2-auth-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-auth-service
 description: LFX Platform V2 Auth Service chart
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"

--- a/charts/lfx-v2-auth-service/values.yaml
+++ b/charts/lfx-v2-auth-service/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 image:
-  repository: ghcr.io/linuxfoundation/lfx-v2-auth-service
+  repository: ghcr.io/linuxfoundation/lfx-v2-auth-service/server
   # tag is the container image tag (overrides appVersion from Chart.yaml)
   tag: ""
   # pullPolicy is the image pull policy


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-535

This pull request makes minor updates to the Helm chart configuration for the LFX V2 Auth Service. The most notable changes are a version bump and an update to the container image repository path.

### Test

```
mauriciosalomao@Mauricios-MacBook-Pro ~ % kubectl describe pod/lfx-v2-auth-service-84f7d8bccd-67mvp -n lfx 
Name:             lfx-v2-auth-service-84f7d8bccd-67mvp
Namespace:        lfx
...
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  33s   default-scheduler  Successfully assigned lfx/lfx-v2-auth-service-84f7d8bccd-67mvp to orbstack
  Normal  Pulling    32s   kubelet            Pulling image "ghcr.io/linuxfoundation/lfx-v2-auth-service/server:latest"
  Normal  Pulled     27s   kubelet            Successfully pulled image "ghcr.io/linuxfoundation/lfx-v2-auth-service/server:latest" in 5.433s (5.433s including waiting). Image size: 23990864 bytes.
  Normal  Created    25s   kubelet            Created container: app
  Normal  Started    25s   kubelet            Started container app
```