### PR TITLE
[LFXV2-597] Fix UserID datatype in Auth0Identity

### DIFF
--- a/internal/domain/model/auth0.go
+++ b/internal/domain/model/auth0.go
@@ -18,7 +18,7 @@ type Auth0User struct {
 // Auth0Identity represents an identity in Auth0
 type Auth0Identity struct {
 	Connection string `json:"connection"`
-	UserID     string `json:"user_id"`
+	UserID     any    `json:"user_id"`
 	Provider   string `json:"provider"`
 	IsSocial   bool   `json:"isSocial"`
 }


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-597

Error:
```
> nats request lfx.auth-service.email_to_username je***s@linuxfoundation.org
{"success":false,"error":"failed to search user: failed to parse API response: json: cannot unmarshal number into Go struct field Auth0Identity.identities.user_id of type string"}
```

## Tests

### Scenario (DEV)

Before:
```
mauriciosalomao@Mauricios-MacBook-Pro ~ % nats --server nats://lfx-platform-nats.lfx.svc.cluster.local:4222 request lfx.auth-service.email_to_username moh****930@gmail.com
10:12:38 Sending request on "lfx.auth-service.email_to_username"
10:12:38 Received with rtt 356.668357ms
{"success":false,"error":"failed to search user: failed to parse API response: json: cannot unmarshal number into Go struct field Auth0Identity.identities.user_id of type string"}
```

After:
```
mauriciosalomao@Mauricios-MacBook-Pro ~ % nats --server nats://lfx-platform-nats.lfx.svc.cluster.local:4222 request lfx.auth-service.email_to_username mo****930@gmail.com
10:16:46 Sending request on "lfx.auth-service.email_to_username"
10:16:47 Received with rtt 610.394699ms
ban****moh****
```