### PR TITLE
Fix JWT audience validation for Auth0 custom domains

### DIFF
--- a/charts/lfx-v2-auth-service/values.yaml
+++ b/charts/lfx-v2-auth-service/values.yaml
@@ -138,6 +138,8 @@ app:
       value: null
     AUTH0_AUDIENCE:
       value: null
+    AUTH0_MANAGEMENT_AUDIENCE:
+      value: null
     # Auth0 LFX Profile Client configuration (Regular Web Application for passwordless flows)
     ## Required when using passwordless email linking flow
     AUTH0_LFX_PROFILE_CLIENT_ID:

--- a/internal/infrastructure/auth0/jwt_parser.go
+++ b/internal/infrastructure/auth0/jwt_parser.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 
+	"github.com/linuxfoundation/lfx-v2-auth-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-auth-service/pkg/errors"
 	"github.com/linuxfoundation/lfx-v2-auth-service/pkg/httpclient"
 	jwtparser "github.com/linuxfoundation/lfx-v2-auth-service/pkg/jwt"
@@ -122,6 +124,9 @@ func NewJWTVerificationConfig(ctx context.Context, domain string, httpClient *ht
 
 			expectedIssuer := fmt.Sprintf("https://%s/", domain)
 			expectedAudience := fmt.Sprintf("https://%s/api/v2/", domain)
+			if override := os.Getenv(constants.Auth0ManagementAudienceEnvKey); override != "" {
+				expectedAudience = override
+			}
 
 			slog.InfoContext(ctx, "JWT signature verification enabled",
 				"issuer", expectedIssuer,

--- a/internal/infrastructure/auth0/jwt_parser.go
+++ b/internal/infrastructure/auth0/jwt_parser.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/linuxfoundation/lfx-v2-auth-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-auth-service/pkg/errors"
@@ -124,7 +125,7 @@ func NewJWTVerificationConfig(ctx context.Context, domain string, httpClient *ht
 
 			expectedIssuer := fmt.Sprintf("https://%s/", domain)
 			expectedAudience := fmt.Sprintf("https://%s/api/v2/", domain)
-			if override := os.Getenv(constants.Auth0ManagementAudienceEnvKey); override != "" {
+			if override := strings.TrimSpace(os.Getenv(constants.Auth0ManagementAudienceEnvKey)); override != "" {
 				expectedAudience = override
 			}
 

--- a/pkg/constants/global.go
+++ b/pkg/constants/global.go
@@ -57,6 +57,9 @@ const (
 	// Auth0AudienceEnvKey is the environment variable key for the Auth0 audience
 	Auth0AudienceEnvKey = "AUTH0_AUDIENCE"
 
+	// Auth0ManagementAudienceEnvKey is the environment variable key for the Auth0 Management API audience override
+	Auth0ManagementAudienceEnvKey = "AUTH0_MANAGEMENT_AUDIENCE"
+
 	// Auth0 LFX Profile Client configuration (Regular Web Application for passwordless flows)
 	// Auth0LFXProfileClientIDEnvKey is the environment variable key for the LFX Profile Auth0 client ID
 	Auth0LFXProfileClientIDEnvKey = "AUTH0_LFX_PROFILE_CLIENT_ID"


### PR DESCRIPTION
Auth0 Management API tokens always use the canonical *.auth0.com domain as the audience, not custom domains like sso.linuxfoundation.org. Add AUTH0_MANAGEMENT_AUDIENCE env var to override the computed audience.