### PR TITLE
[LFXV2-1403] Add indexer contract doc for auth service

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ Link verified identities (such as verified email addresses) to user accounts.
 
 ---
 
+#### Indexer Contract
+
+Documents what data this service sends to the indexer service (currently none).
+
+**[View Indexer Contract](docs/indexer-contract.md)**
+
+---
+
 ### Configuration
 
 ##### NATS Configuration

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -1,0 +1,19 @@
+# Indexer Contract — Auth Service
+
+This document is the authoritative reference for all data the auth service sends to the indexer service, which makes resources searchable via the [query service](https://github.com/linuxfoundation/lfx-v2-query-service).
+
+**Update this document in the same PR as any change to indexer message construction.**
+
+---
+
+## Summary
+
+The auth service does **not** send any data to the indexer service. No resource types are indexed, and no index documents are expected.
+
+This service is a pure request/reply NATS microservice that provides authentication and user profile operations. There is no write path to the indexer.
+
+---
+
+## Resource Types
+
+_None at this time._


### PR DESCRIPTION
## Summary

- Confirms the auth service sends no data to the indexer service
- Creates `docs/indexer-contract.md` as the authoritative reference (currently no resource types are indexed)
- Adds a pointer to the new doc from the README, following the pattern established by `lfx-v2-committee-service`

## Ticket

[LFXV2-1403](https://linuxfoundation.atlassian.net/browse/LFXV2-1403)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1403]: https://linuxfoundation.atlassian.net/browse/LFXV2-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ