### PR TITLE
Add deployment annotation for Backstage ingestion

### DIFF
--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -21,6 +22,7 @@ spec:
       {{- end }}
       labels:
         app: {{ .Chart.Name }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
-      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:


### PR DESCRIPTION
Spotify Backstage can pull kubernetes data from components using deployment annotations. This service is missing the name annotation needed to discover it.