### PR TITLE
feat: support raw PEM in AUTH0_M2M_PRIVATE_BASE64_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The Auth0 integration can be configured using environment variables:
   - **If not set, defaults to `${AUTH0_TENANT}.auth0.com`**
 - `AUTH0_M2M_CLIENT_ID`: Auth0 Machine-to-Machine application client ID
   - **Required when using Auth0 repository type**
-- `AUTH0_M2M_PRIVATE_BASE64_KEY`: Base64-encoded private key for Auth0 M2M authentication
+- `AUTH0_M2M_PRIVATE_BASE64_KEY`: Private key for Auth0 M2M authentication (base64-encoded or raw PEM)
   - **Required when using Auth0 repository type**
 - `AUTH0_AUDIENCE`: Auth0 API audience/identifier for the Management API
   - **Required when using Auth0 repository type**

--- a/internal/infrastructure/auth0/impersonation.go
+++ b/internal/infrastructure/auth0/impersonation.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -60,17 +59,17 @@ func NewImpersonationFlow(ctx context.Context, domain string) (port.Impersonator
 		return nil, errors.NewUnexpected(constants.Auth0LFXv2APIAudienceEnvKey + " is required")
 	}
 
-	privateKeyB64 := os.Getenv(constants.Auth0M2MPrivateBase64KeyEnvKey)
-	if privateKeyB64 == "" {
+	privateKeyRaw := os.Getenv(constants.Auth0M2MPrivateBase64KeyEnvKey)
+	if privateKeyRaw == "" {
 		return nil, errors.NewUnexpected(constants.Auth0M2MPrivateBase64KeyEnvKey + " is required")
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(privateKeyB64)
+	privateKeyPEM, err := decodePrivateKey(privateKeyRaw)
 	if err != nil {
-		return nil, errors.NewUnexpected("failed to base64-decode "+constants.Auth0M2MPrivateBase64KeyEnvKey, err)
+		return nil, err
 	}
 
-	rsaKey, err := parseRSAPrivateKey(decoded)
+	rsaKey, err := parseRSAPrivateKey([]byte(privateKeyPEM))
 	if err != nil {
 		return nil, errors.NewUnexpected("failed to parse private key", err)
 	}

--- a/internal/infrastructure/auth0/token.go
+++ b/internal/infrastructure/auth0/token.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/auth0/go-auth0/authentication"
@@ -150,18 +151,15 @@ func loadM2MConfigFromEnv(ctx context.Context, config Config) (m2mConfig, error)
 		return m2mConfig{}, errors.NewUnexpected(constants.Auth0AudienceEnvKey + " is required")
 	}
 
-	// private key is base64 encoded
-	privateKey := os.Getenv(constants.Auth0M2MPrivateBase64KeyEnvKey)
-	if privateKey == "" {
+	privateKeyRaw := os.Getenv(constants.Auth0M2MPrivateBase64KeyEnvKey)
+	if privateKeyRaw == "" {
 		return m2mConfig{}, errors.NewUnexpected(constants.Auth0M2MPrivateBase64KeyEnvKey + " is required")
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(privateKey)
+	privateKey, err := decodePrivateKey(privateKeyRaw)
 	if err != nil {
-		return m2mConfig{}, errors.NewUnexpected("failed to base64-decode "+constants.Auth0M2MPrivateBase64KeyEnvKey, err)
+		return m2mConfig{}, err
 	}
-	privateKey = string(decoded)
-	//
 
 	// Optional organization
 	organization := os.Getenv("AUTH0_ORGANIZATION")
@@ -246,4 +244,18 @@ func NewProfileClientAuthConfig(ctx context.Context, domain string) (*authentica
 		"domain", domain)
 
 	return authConfig, nil
+}
+
+// decodePrivateKey accepts a private key value that may be base64-encoded or raw PEM.
+// If the value is already a PEM key (starts with "-----BEGIN"), it is returned as-is.
+// Otherwise it is base64-decoded.
+func decodePrivateKey(raw string) (string, error) {
+	if strings.HasPrefix(raw, "-----BEGIN") {
+		return raw, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return "", errors.NewUnexpected("failed to decode "+constants.Auth0M2MPrivateBase64KeyEnvKey+": value is neither valid PEM nor valid base64", err)
+	}
+	return string(decoded), nil
 }

--- a/pkg/constants/global.go
+++ b/pkg/constants/global.go
@@ -51,7 +51,7 @@ const (
 	// Auth0M2MClientIDEnvKey is the environment variable key for the Auth0 M2M client ID
 	Auth0M2MClientIDEnvKey = "AUTH0_M2M_CLIENT_ID"
 
-	// Auth0M2MPrivateBase64KeyEnvKey is the environment variable key for the Auth0 M2M base64 encoded private key
+	// Auth0M2MPrivateBase64KeyEnvKey is the environment variable key for the Auth0 M2M private key (base64-encoded or raw PEM)
 	Auth0M2MPrivateBase64KeyEnvKey = "AUTH0_M2M_PRIVATE_BASE64_KEY"
 
 	// Auth0AudienceEnvKey is the environment variable key for the Auth0 audience


### PR DESCRIPTION
## Summary
- Auto-detect whether `AUTH0_M2M_PRIVATE_BASE64_KEY` is base64-encoded or raw PEM, accepting either format
- Extract shared `decodePrivateKey()` helper used by both `loadM2MConfigFromEnv()` and `NewImpersonationFlow()`
- Update docs (README, constant comments) to reflect both formats are accepted

Issue: LFXV2-1515

🤖 Generated with [Claude Code](https://claude.com/claude-code)