### PR TITLE
refactor: align user_emails.read with user_identity.list flow

### DIFF
--- a/docs/user_emails.md
+++ b/docs/user_emails.md
@@ -11,42 +11,19 @@ To retrieve user email addresses (both primary and alternate emails), send a NAT
 **Subject:** `lfx.auth-service.user_emails.read`  
 **Pattern:** Request/Reply
 
-The service supports a **hybrid approach** for user email retrieval, accepting multiple input types and automatically determining the appropriate lookup strategy based on the input format.
-
-### Hybrid Input Support
-
-The service intelligently handles different input types:
-
-1. **JWT Tokens** (Auth0) or **Authelia Tokens** (Authelia)
-2. **Subject Identifiers** (canonical user IDs)
-3. **Usernames**
-
 ### Request Payload
 
-The request payload can be any of the following formats (no JSON wrapping required):
-
-**JWT Token (Auth0):**
-```
-eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
-```
-
-**Subject Identifier:**
-```
-auth0|123456789
+```json
+{
+  "user": {
+    "auth_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+  }
+}
 ```
 
-**Username:**
-```
-john.doe
-```
+### Request Fields
 
-### Lookup Strategy
-
-The service automatically determines the lookup strategy based on input format:
-
-- **Token Strategy**: If input is a JWT/Authelia token, validates the token and extracts the subject identifier
-- **Canonical Lookup**: If input contains `|` (pipe character) or is a UUID, treats as subject identifier for direct lookup
-- **Username Search**: If input doesn't match above patterns, treats as username for search lookup
+- `user.auth_token` (string, required): A valid JWT token identifying the authenticated user
 
 ### Reply
 
@@ -60,6 +37,10 @@ The service returns a structured reply with user email information:
     "primary_email": "john.doe@example.com",
     "alternate_emails": [
       {
+        "email": "john.doe@example.com",
+        "verified": true
+      },
+      {
         "email": "john.doe@personal.com",
         "verified": true
       },
@@ -72,7 +53,9 @@ The service returns a structured reply with user email information:
 }
 ```
 
-**Success Reply (No Alternate Emails):**
+The `alternate_emails` array contains every email identity linked to the user (Auth0 connection `email`), **including the primary email**. Callers identify the primary by matching an entry's `email` field to the top-level `primary_email`.
+
+**Success Reply (No Email Identities):**
 ```json
 {
   "success": true,
@@ -102,42 +85,33 @@ The service returns a structured reply with user email information:
 ### Response Fields
 
 - `primary_email` (string): The user's primary email address registered with the identity provider
-- `alternate_emails` (array): List of alternate email addresses linked to the user account
-  - `email` (string): The alternate email address
-  - `verified` (boolean): Whether the alternate email has been verified
+- `alternate_emails` (array): Every email identity linked to the user account via the `email` connection — **including the primary**. To find the primary entry, match `email` against `primary_email`.
+  - `email` (string): The email address
+  - `verified` (boolean): Whether the email has been verified
 
 ### Example using NATS CLI
 
 ```bash
-# Retrieve user emails using JWT token
-nats request lfx.auth-service.user_emails.read "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
-
-# Retrieve user emails using subject identifier
-nats request lfx.auth-service.user_emails.read "auth0|123456789"
-
-# Retrieve user emails using username
-nats request lfx.auth-service.user_emails.read "john.doe"
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."}}'
 ```
 
 ### Example Response Processing
 
 ```bash
 # Get and format the response
-nats request lfx.auth-service.user_emails.read "john.doe" | jq '.'
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"<token>"}}' | jq '.'
 
 # Extract only the primary email
-nats request lfx.auth-service.user_emails.read "john.doe" | jq -r '.data.primary_email'
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"<token>"}}' | jq -r '.data.primary_email'
 
 # List all verified alternate emails
-nats request lfx.auth-service.user_emails.read "john.doe" | jq -r '.data.alternate_emails[] | select(.verified == true) | .email'
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"<token>"}}' | jq -r '.data.alternate_emails[] | select(.verified == true) | .email'
 
-# Count total email addresses (primary + alternates)
-nats request lfx.auth-service.user_emails.read "john.doe" | jq '.data.alternate_emails | length + 1'
+# Count total email identities (primary is already included in alternate_emails)
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"<token>"}}' | jq '.data.alternate_emails | length'
 ```
 
 **Important Notes:**
-- The service automatically detects input type and applies the appropriate lookup strategy
-- JWT tokens are validated for signature and expiration before extracting subject information
 - The target identity provider is determined by the `USER_REPOSITORY_TYPE` environment variable
 - Primary email is always present if the user exists
 - Alternate emails array may be empty if the user has not linked any additional email addresses
@@ -254,22 +228,22 @@ nats request lfx.auth-service.user_emails.set_primary \
 When you need to verify if a user owns a specific email address:
 ```bash
 # Get all user emails
-nats request lfx.auth-service.user_emails.read "john.doe"
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"<token>"}}'
 ```
 
 ### Email Communication
 When you need to send notifications to all verified user email addresses:
 ```bash
-# Extract all verified emails (primary + verified alternates)
-nats request lfx.auth-service.user_emails.read "john.doe" | \
-  jq -r '(.data.primary_email, (.data.alternate_emails[] | select(.verified == true) | .email))'
+# Extract all verified emails (primary is already in alternate_emails)
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"<token>"}}' | \
+  jq -r '.data.alternate_emails[] | select(.verified == true) | .email'
 ```
 
 ### Account Recovery
 When displaying email options for account recovery:
 ```bash
 # Show all verified email addresses for recovery selection
-nats request lfx.auth-service.user_emails.read "auth0|123456789" | \
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"<token>"}}' | \
   jq '.data.alternate_emails[] | select(.verified == true)'
 ```
 

--- a/docs/user_emails.md
+++ b/docs/user_emails.md
@@ -53,9 +53,9 @@ The service returns a structured reply with user email information:
 }
 ```
 
-The `alternate_emails` array contains every email identity linked to the user (Auth0 connection `email`), **including the primary email**. Callers identify the primary by matching an entry's `email` field to the top-level `primary_email`.
+The `alternate_emails` array contains every email identity linked to the user from the Auth0 `email` connection. It includes the primary email only when that same address is present in one of those linked `email` identities. Callers should use the top-level `primary_email` as the authoritative primary address and, when present, may identify the corresponding entry by matching an entry's `email` field to `primary_email`.
 
-**Success Reply (No Email Identities):**
+**Success Reply (No Email Identities in Auth0 `email` Connection):**
 ```json
 {
   "success": true,

--- a/internal/domain/model/identity.go
+++ b/internal/domain/model/identity.go
@@ -7,6 +7,7 @@ package model
 type Identity struct {
 	Provider      string `json:"provider"                  yaml:"provider"`                 // e.g. "google-oauth2", "linkedin", "github"
 	IdentityID    string `json:"identity_id"               yaml:"identity_id"`              // provider-specific user ID (part after "|" in Auth0)
+	Connection    string `json:"connection,omitempty"      yaml:"connection,omitempty"`     // Auth0 connection name, e.g. "email", "Username-Password-Authentication"
 	Email         string `json:"email,omitempty"           yaml:"email,omitempty"`          // email from the provider's profileData, if available
 	EmailVerified bool   `json:"email_verified,omitempty"  yaml:"email_verified,omitempty"` // email verification status from the provider's profileData
 	Nickname      string `json:"nickname,omitempty"        yaml:"nickname,omitempty"`       // username/handle from the provider's profileData (e.g. GitHub username)

--- a/internal/infrastructure/auth0/filter.go
+++ b/internal/infrastructure/auth0/filter.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	usernamePasswordAuthenticationFilter = "Username-Password-Authentication"
-	emailAuthenticationFilter            = "email"
+	emailAuthenticationFilter            = constants.EmailConnection
 )
 
 var (

--- a/internal/infrastructure/auth0/filter.go
+++ b/internal/infrastructure/auth0/filter.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	usernamePasswordAuthenticationFilter = "Username-Password-Authentication"
+	usernamePasswordAuthenticationFilter = constants.Auth0UsernamePasswordConnection
 	emailAuthenticationFilter            = constants.EmailConnection
 )
 

--- a/internal/infrastructure/auth0/models.go
+++ b/internal/infrastructure/auth0/models.go
@@ -85,23 +85,6 @@ func (u *Auth0User) ToUser() *model.User {
 		}
 	}
 
-	var alternateEmails []model.Email
-	for _, identity := range u.Identities {
-		if identity.Connection != emailAuthenticationFilter {
-			continue
-		}
-		if identity.ProfileData == nil || identity.ProfileData.Email == "" {
-			continue
-		}
-		if identity.ProfileData.Email == u.Email {
-			continue
-		}
-		alternateEmails = append(alternateEmails, model.Email{
-			Email:    identity.ProfileData.Email,
-			Verified: identity.ProfileData.EmailVerified,
-		})
-	}
-
 	var identities []model.Identity
 	for _, auth0Id := range u.Identities {
 		var identityID string
@@ -117,6 +100,7 @@ func (u *Auth0User) ToUser() *model.User {
 		identity := model.Identity{
 			Provider:   auth0Id.Provider,
 			IdentityID: identityID,
+			Connection: auth0Id.Connection,
 			IsSocial:   auth0Id.IsSocial,
 		}
 		if auth0Id.ProfileData != nil {
@@ -129,12 +113,11 @@ func (u *Auth0User) ToUser() *model.User {
 	}
 
 	return &model.User{
-		UserID:          u.UserID,
-		Username:        u.Username,
-		PrimaryEmail:    u.Email,
-		AlternateEmails: alternateEmails,
-		Identities:      identities,
-		UserMetadata:    meta,
+		UserID:       u.UserID,
+		Username:     u.Username,
+		PrimaryEmail: u.Email,
+		Identities:   identities,
+		UserMetadata: meta,
 	}
 }
 

--- a/internal/infrastructure/auth0/models_test.go
+++ b/internal/infrastructure/auth0/models_test.go
@@ -209,39 +209,39 @@ func TestAuth0User_ToUser(t *testing.T) {
 			},
 		},
 		{
-			name: "alternate emails are extracted from email identities",
+			name: "Connection field is populated on identities",
 			auth0User: Auth0User{
 				UserID: "auth0|abc123",
 				Email:  "primary@example.com",
 				Identities: []Auth0Identity{
 					{
 						Connection:  "email",
+						Provider:    "email",
+						UserID:      "alt-id-1",
 						ProfileData: &Auth0ProfileData{Email: "alt1@example.com", EmailVerified: true},
 					},
 					{
-						Connection:  "email",
-						ProfileData: &Auth0ProfileData{Email: "alt2@example.com", EmailVerified: false},
-					},
-					{
 						Connection:  "google-oauth2",
+						Provider:    "google-oauth2",
+						UserID:      "g-111",
+						IsSocial:    true,
 						ProfileData: &Auth0ProfileData{Email: "social@example.com", EmailVerified: true},
 					},
 					{
-						Connection:  "email",
-						ProfileData: &Auth0ProfileData{Email: "primary@example.com", EmailVerified: true},
-					},
-					{
-						Connection:  "email",
-						ProfileData: nil,
+						Connection: "Username-Password-Authentication",
+						Provider:   "auth0",
+						UserID:     "db-user",
 					},
 				},
 			},
 			validate: func(t *testing.T, user *model.User) {
-				require.Len(t, user.AlternateEmails, 2)
-				assert.Equal(t, "alt1@example.com", user.AlternateEmails[0].Email)
-				assert.True(t, user.AlternateEmails[0].Verified)
-				assert.Equal(t, "alt2@example.com", user.AlternateEmails[1].Email)
-				assert.False(t, user.AlternateEmails[1].Verified)
+				require.Len(t, user.Identities, 3)
+				assert.Equal(t, "email", user.Identities[0].Connection)
+				assert.Equal(t, "alt1@example.com", user.Identities[0].Email)
+				assert.True(t, user.Identities[0].EmailVerified)
+				assert.Equal(t, "google-oauth2", user.Identities[1].Connection)
+				assert.Equal(t, "Username-Password-Authentication", user.Identities[2].Connection)
+				assert.Nil(t, user.AlternateEmails)
 			},
 		},
 	}

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -538,9 +538,12 @@ func (u *userReaderWriter) SetPrimaryEmail(ctx context.Context, userID string, e
 
 	// Verify the email is one of the user's verified linked email identities
 	found := false
-	for _, alt := range fullUser.AlternateEmails {
-		if strings.EqualFold(alt.Email, email) {
-			if !alt.Verified {
+	for _, id := range fullUser.Identities {
+		if id.Connection != constants.EmailConnection {
+			continue
+		}
+		if strings.EqualFold(id.Email, email) {
+			if !id.EmailVerified {
 				return errors.NewValidation("email is not verified and cannot be set as primary")
 			}
 			found = true

--- a/internal/infrastructure/mock/user.go
+++ b/internal/infrastructure/mock/user.go
@@ -551,7 +551,7 @@ func (u *userWriter) SetPrimaryEmail(ctx context.Context, userID string, email s
 }
 
 func (u *userWriter) MetadataLookup(ctx context.Context, input string, requiredScopes ...string) (*model.User, error) {
-	slog.DebugContext(ctx, "mock: metadata lookup", "input", input)
+	slog.DebugContext(ctx, "mock: metadata lookup", "input", redaction.Redact(input))
 
 	// Trim whitespace from input
 	input = strings.TrimSpace(input)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -236,27 +236,72 @@ func (m *messageHandlerOrchestrator) GetUserMetadata(ctx context.Context, msg po
 	return responseJSON, nil
 }
 
-// GetUserEmails retrieves the user emails based on the input strategy
+// userEmailsRequest represents the input for retrieving user emails
+type userEmailsRequest struct {
+	User struct {
+		AuthToken string `json:"auth_token"`
+	} `json:"user"`
+}
+
+// GetUserEmails retrieves the user emails based on an auth token
 func (m *messageHandlerOrchestrator) GetUserEmails(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 
-	user, errGetUser := m.getUserByInput(ctx, msg)
-	if errGetUser != nil {
-		slog.ErrorContext(ctx, "error getting user emails",
-			"error", errGetUser,
-			"input", redaction.Redact(string(msg.Data())),
+	if m.userReader == nil {
+		return m.errorResponse("auth service unavailable"), nil
+	}
+
+	var request userEmailsRequest
+	if err := json.Unmarshal(msg.Data(), &request); err != nil {
+		return m.errorResponse("failed to unmarshal request"), nil
+	}
+
+	authToken := strings.TrimSpace(request.User.AuthToken)
+	if authToken == "" {
+		return m.errorResponse("auth_token is required"), nil
+	}
+
+	slog.DebugContext(ctx, "get user emails",
+		"input", redaction.Redact(authToken),
+	)
+
+	user, err := m.userReader.MetadataLookup(ctx, authToken)
+	if err != nil {
+		slog.ErrorContext(ctx, "error looking up user for email read",
+			"error", err,
 		)
-		return m.errorResponse(errGetUser.Error()), nil
+		return m.errorResponse(err.Error()), nil
+	}
+
+	fullUser, err := m.userReader.GetUser(ctx, user)
+	if err != nil {
+		slog.ErrorContext(ctx, "error getting user for email read",
+			"error", err,
+		)
+		return m.errorResponse(err.Error()), nil
+	}
+
+	alternateEmails := make([]model.Email, 0, len(fullUser.Identities))
+	for _, id := range fullUser.Identities {
+		if id.Connection != constants.EmailConnection {
+			continue
+		}
+		if id.Email == "" {
+			continue
+		}
+		alternateEmails = append(alternateEmails, model.Email{
+			Email:    id.Email,
+			Verified: id.EmailVerified,
+		})
 	}
 
 	response := UserDataResponse{
 		Success: true,
-		Data:    map[string]any{"primary_email": user.PrimaryEmail, "alternate_emails": user.AlternateEmails},
+		Data:    map[string]any{"primary_email": fullUser.PrimaryEmail, "alternate_emails": alternateEmails},
 	}
 
 	responseJSON, err := json.Marshal(response)
 	if err != nil {
-		errorResponseJSON := m.errorResponse("failed to marshal response")
-		return errorResponseJSON, nil
+		return m.errorResponse("failed to marshal response"), nil
 	}
 
 	return responseJSON, nil
@@ -416,8 +461,18 @@ func (m *messageHandlerOrchestrator) checkEmailExists(ctx context.Context, email
 				return errs.NewValidation("email already linked")
 			}
 
+			// Authelia and Mock adapters expose linked emails via AlternateEmails;
+			// the Auth0 adapter exposes them as identities with Connection == "email".
 			for _, alternateEmail := range user.AlternateEmails {
 				if strings.EqualFold(alternateEmail.Email, email) && alternateEmail.Verified {
+					return errs.NewValidation("email already linked")
+				}
+			}
+			for _, id := range user.Identities {
+				if id.Connection != constants.EmailConnection {
+					continue
+				}
+				if strings.EqualFold(id.Email, email) && id.EmailVerified {
 					return errs.NewValidation("email already linked")
 				}
 			}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2004,6 +2004,223 @@ func TestMessageHandlerOrchestrator_LinkIdentity(t *testing.T) {
 	}
 }
 
+func TestMessageHandlerOrchestrator_GetUserEmails(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		messageData    []byte
+		mockReader     *mockUserServiceReader
+		expectSuccess  bool
+		expectError    string
+		validateResult func(t *testing.T, result []byte)
+	}{
+		{
+			name:        "returns primary and alternate emails",
+			messageData: []byte(`{"user":{"auth_token":"valid-token"}}`),
+			mockReader: &mockUserServiceReader{
+				metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+					return &model.User{UserID: "auth0|123"}, nil
+				},
+				getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+					return &model.User{
+						UserID:       "auth0|123",
+						PrimaryEmail: "primary@example.com",
+						Identities: []model.Identity{
+							{Connection: constants.EmailConnection, Email: "alt1@example.com", EmailVerified: true},
+							{Connection: constants.EmailConnection, Email: "alt2@example.com", EmailVerified: false},
+							{Connection: "google-oauth2", Email: "social@example.com", EmailVerified: true},
+						},
+					}, nil
+				},
+			},
+			expectSuccess: true,
+			validateResult: func(t *testing.T, result []byte) {
+				var response struct {
+					Success bool `json:"success"`
+					Data    struct {
+						PrimaryEmail    string       `json:"primary_email"`
+						AlternateEmails []model.Email `json:"alternate_emails"`
+					} `json:"data"`
+				}
+				if err := json.Unmarshal(result, &response); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if response.Data.PrimaryEmail != "primary@example.com" {
+					t.Errorf("primary_email = %q, want %q", response.Data.PrimaryEmail, "primary@example.com")
+				}
+				if len(response.Data.AlternateEmails) != 2 {
+					t.Fatalf("expected 2 alternate emails, got %d", len(response.Data.AlternateEmails))
+				}
+				if response.Data.AlternateEmails[0].Email != "alt1@example.com" {
+					t.Errorf("alternate_emails[0].email = %q, want %q", response.Data.AlternateEmails[0].Email, "alt1@example.com")
+				}
+				if !response.Data.AlternateEmails[0].Verified {
+					t.Error("expected alternate_emails[0].verified = true")
+				}
+			},
+		},
+		{
+			name:        "includes primary email in alternate_emails for identification",
+			messageData: []byte(`{"user":{"auth_token":"valid-token"}}`),
+			mockReader: &mockUserServiceReader{
+				metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+					return &model.User{UserID: "auth0|123"}, nil
+				},
+				getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+					return &model.User{
+						UserID:       "auth0|123",
+						PrimaryEmail: "primary@example.com",
+						Identities: []model.Identity{
+							{Connection: constants.EmailConnection, Email: "primary@example.com", EmailVerified: true},
+							{Connection: constants.EmailConnection, Email: "alt@example.com", EmailVerified: true},
+						},
+					}, nil
+				},
+			},
+			expectSuccess: true,
+			validateResult: func(t *testing.T, result []byte) {
+				var response struct {
+					Success bool `json:"success"`
+					Data    struct {
+						PrimaryEmail    string        `json:"primary_email"`
+						AlternateEmails []model.Email `json:"alternate_emails"`
+					} `json:"data"`
+				}
+				if err := json.Unmarshal(result, &response); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if response.Data.PrimaryEmail != "primary@example.com" {
+					t.Errorf("primary_email = %q, want %q", response.Data.PrimaryEmail, "primary@example.com")
+				}
+				if len(response.Data.AlternateEmails) != 2 {
+					t.Fatalf("expected 2 alternate emails (primary included), got %d", len(response.Data.AlternateEmails))
+				}
+				foundPrimary := false
+				for _, e := range response.Data.AlternateEmails {
+					if e.Email == response.Data.PrimaryEmail {
+						foundPrimary = true
+					}
+				}
+				if !foundPrimary {
+					t.Error("expected primary email to appear in alternate_emails")
+				}
+			},
+		},
+		{
+			name:        "returns empty alternate_emails array when no email identities",
+			messageData: []byte(`{"user":{"auth_token":"valid-token"}}`),
+			mockReader: &mockUserServiceReader{
+				metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+					return &model.User{UserID: "auth0|123"}, nil
+				},
+				getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+					return &model.User{
+						UserID:       "auth0|123",
+						PrimaryEmail: "primary@example.com",
+						Identities: []model.Identity{
+							{Connection: "google-oauth2", Email: "social@example.com"},
+						},
+					}, nil
+				},
+			},
+			expectSuccess: true,
+			validateResult: func(t *testing.T, result []byte) {
+				var response struct {
+					Success bool `json:"success"`
+					Data    struct {
+						AlternateEmails []model.Email `json:"alternate_emails"`
+					} `json:"data"`
+				}
+				if err := json.Unmarshal(result, &response); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if len(response.Data.AlternateEmails) != 0 {
+					t.Errorf("expected 0 alternate emails, got %d", len(response.Data.AlternateEmails))
+				}
+			},
+		},
+		{
+			name:          "missing auth_token",
+			messageData:   []byte(`{"user":{"auth_token":""}}`),
+			mockReader:    &mockUserServiceReader{},
+			expectSuccess: false,
+			expectError:   "auth_token is required",
+		},
+		{
+			name:          "invalid json payload",
+			messageData:   []byte(`not-json`),
+			mockReader:    &mockUserServiceReader{},
+			expectSuccess: false,
+			expectError:   "failed to unmarshal request",
+		},
+		{
+			name:          "reader unavailable",
+			messageData:   []byte(`{"user":{"auth_token":"token"}}`),
+			mockReader:    nil,
+			expectSuccess: false,
+			expectError:   "auth service unavailable",
+		},
+		{
+			name:        "metadata lookup failure",
+			messageData: []byte(`{"user":{"auth_token":"bad-token"}}`),
+			mockReader: &mockUserServiceReader{
+				metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+					return nil, errors.NewValidation("invalid token")
+				},
+			},
+			expectSuccess: false,
+			expectError:   "invalid token",
+		},
+		{
+			name:        "get user failure",
+			messageData: []byte(`{"user":{"auth_token":"valid-token"}}`),
+			mockReader: &mockUserServiceReader{
+				metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+					return &model.User{UserID: "auth0|123"}, nil
+				},
+				getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+					return nil, errors.NewNotFound("user not found")
+				},
+			},
+			expectSuccess: false,
+			expectError:   "user not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &mockTransportMessenger{data: tt.messageData}
+
+			var opts []MessageHandlerOrchestratorOption
+			if tt.mockReader != nil {
+				opts = append(opts, WithUserReaderForMessageHandler(tt.mockReader))
+			}
+			handler := NewMessageHandlerOrchestrator(opts...)
+
+			result, err := handler.GetUserEmails(ctx, msg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var response UserDataResponse
+			if err := json.Unmarshal(result, &response); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			if response.Success != tt.expectSuccess {
+				t.Errorf("success = %v, want %v (error: %s)", response.Success, tt.expectSuccess, response.Error)
+			}
+			if tt.expectError != "" && response.Error != tt.expectError {
+				t.Errorf("error = %q, want %q", response.Error, tt.expectError)
+			}
+			if tt.validateResult != nil {
+				tt.validateResult(t, result)
+			}
+		})
+	}
+}
+
 func TestMessageHandlerOrchestrator_ListIdentities(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2039,7 +2039,7 @@ func TestMessageHandlerOrchestrator_GetUserEmails(t *testing.T) {
 				var response struct {
 					Success bool `json:"success"`
 					Data    struct {
-						PrimaryEmail    string       `json:"primary_email"`
+						PrimaryEmail    string        `json:"primary_email"`
 						AlternateEmails []model.Email `json:"alternate_emails"`
 					} `json:"data"`
 				}

--- a/pkg/constants/user.go
+++ b/pkg/constants/user.go
@@ -26,4 +26,6 @@ const (
 const (
 	// Auth0UsernamePasswordConnection is the Auth0 database connection name for username/password authentication.
 	Auth0UsernamePasswordConnection = "Username-Password-Authentication"
+	// EmailConnection is the Auth0 connection name for passwordless email identities.
+	EmailConnection = "email"
 )

--- a/pkg/jwt/parser.go
+++ b/pkg/jwt/parser.go
@@ -116,7 +116,7 @@ func ParseUnverified(ctx context.Context, tokenString string, opts *ParseOptions
 	}
 
 	slog.DebugContext(ctx, "JWT parsed successfully",
-		"subject", claims.Subject,
+		"sub", claims.Subject,
 		"expires_at", claims.ExpiresAt,
 		"scope", claims.Scope)
 
@@ -191,7 +191,7 @@ func ParseVerified(ctx context.Context, tokenString string, opts *ParseOptions) 
 	}
 
 	slog.DebugContext(ctx, "JWT parsed and verified successfully",
-		"subject", claims.Subject,
+		"sub", claims.Subject,
 		"issuer", claims.Issuer,
 		"audience", claims.Audience,
 		"expires_at", claims.ExpiresAt,
@@ -270,7 +270,7 @@ func ExtractSubject(ctx context.Context, tokenString string) (string, error) {
 		return "", errors.NewValidation("missing or invalid 'sub' claim in token")
 	}
 
-	slog.DebugContext(ctx, "extracted subject from JWT", "subject", claims.Subject)
+	slog.DebugContext(ctx, "extracted subject from JWT", "sub", claims.Subject)
 	return claims.Subject, nil
 }
 


### PR DESCRIPTION
Rewrite GetUserEmails to mirror ListIdentities: accept {user:{auth_token}}, build alternate_emails in the handler by filtering fullUser.Identities on Connection == "email", and include the primary (callers match email against primary_email to find it).

Move the connection filter out of Auth0User.ToUser() and expose the connection on model.Identity; fix the ripple into SetPrimaryEmail and checkEmailExists which previously relied on the pre-computed AlternateEmails. Redact the raw token logged by mock MetadataLookup and rename the JWT log key from "subject" to "sub" to stop colliding with the NATS subject field.