### PR TITLE
feat: publish lfx.user_profile.updated event after metadata update

### DIFF
--- a/cmd/server/service/providers.go
+++ b/cmd/server/service/providers.go
@@ -193,6 +193,7 @@ func QueueSubscriptions(ctx context.Context) error {
 		service.WithIdentityLinkerForMessageHandler(userReaderWriter),
 		service.WithIdentityUnlinkerForMessageHandler(userReaderWriter),
 		service.WithPasswordHandlerForMessageHandler(userReaderWriter),
+		service.WithEventPublisherForMessageHandler(natsClient),
 	}
 
 	if os.Getenv(constants.UserRepositoryTypeEnvKey) == constants.UserRepositoryTypeAuth0 {

--- a/internal/domain/port/event_publisher.go
+++ b/internal/domain/port/event_publisher.go
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package port
+
+import "context"
+
+// EventPublisher publishes domain events to a messaging system.
+type EventPublisher interface {
+	Publish(ctx context.Context, subject string, data []byte) error
+}

--- a/internal/infrastructure/nats/client.go
+++ b/internal/infrastructure/nats/client.go
@@ -87,6 +87,15 @@ func (c *NATSClient) GetKVStore(bucketName string) (jetstream.KeyValue, bool) {
 	return kvStore, exists
 }
 
+// Publish publishes a message to a NATS subject. Used for fire-and-forget
+// domain events (not request/reply).
+func (c *NATSClient) Publish(ctx context.Context, subject string, data []byte) error {
+	if err := c.IsReady(ctx); err != nil {
+		return err
+	}
+	return c.conn.Publish(subject, data)
+}
+
 // SubscribeWithTransportMessenger subscribes to a subject with proper TransportMessenger handling
 func (c *NATSClient) SubscribeWithTransportMessenger(ctx context.Context, subject string, queueName string, handler func(context.Context, port.TransportMessenger)) (*nats.Subscription, error) {
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -462,12 +462,12 @@ func (m *messageHandlerOrchestrator) UpdateUser(ctx context.Context, msg port.Tr
 		if jsonErr != nil {
 			slog.WarnContext(ctx, "failed to marshal user profile updated event",
 				"error", jsonErr,
-				"user_id", user.UserID,
+				"user_id", redaction.Redact(user.UserID),
 			)
 		} else if pubErr := m.eventPublisher.Publish(ctx, constants.UserProfileUpdatedSubject, eventJSON); pubErr != nil {
 			slog.WarnContext(ctx, "failed to publish user profile updated event",
 				"error", pubErr,
-				"user_id", user.UserID,
+				"user_id", redaction.Redact(user.UserID),
 			)
 		}
 	}

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/linuxfoundation/lfx-v2-auth-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-auth-service/internal/domain/port"
@@ -16,6 +17,16 @@ import (
 	errs "github.com/linuxfoundation/lfx-v2-auth-service/pkg/errors"
 	"github.com/linuxfoundation/lfx-v2-auth-service/pkg/redaction"
 )
+
+// UserProfileUpdatedEvent is published after a successful user_metadata update.
+// Consumers use the full UserMetadata object (not just changed fields) to sync
+// profile state to other systems.
+type UserProfileUpdatedEvent struct {
+	UserID    string              `json:"user_id"`
+	Principal string              `json:"principal"`
+	Metadata  *model.UserMetadata `json:"user_metadata"`
+	Timestamp time.Time           `json:"timestamp"`
+}
 
 // UserDataResponse represents the response structure for user update operations
 type UserDataResponse struct {
@@ -34,6 +45,7 @@ type messageHandlerOrchestrator struct {
 	identityUnlinker port.IdentityLinker
 	passwordHandler  port.PasswordHandler
 	impersonator     port.Impersonator
+	eventPublisher   port.EventPublisher
 }
 
 // MessageHandlerOrchestratorOption defines a function type for setting options
@@ -85,6 +97,13 @@ func WithPasswordHandlerForMessageHandler(passwordHandler port.PasswordHandler) 
 func WithImpersonatorForMessageHandler(impersonator port.Impersonator) MessageHandlerOrchestratorOption {
 	return func(m *messageHandlerOrchestrator) {
 		m.impersonator = impersonator
+	}
+}
+
+// WithEventPublisherForMessageHandler sets the event publisher for the message handler orchestrator
+func WithEventPublisherForMessageHandler(eventPublisher port.EventPublisher) MessageHandlerOrchestratorOption {
+	return func(m *messageHandlerOrchestrator) {
+		m.eventPublisher = eventPublisher
 	}
 }
 
@@ -427,6 +446,26 @@ func (m *messageHandlerOrchestrator) UpdateUser(ctx context.Context, msg port.Tr
 	if err != nil {
 		responseJSON := m.errorResponse(err.Error())
 		return responseJSON, nil
+	}
+
+	// Publish domain event so downstream consumers (e.g. v1-sync-helper) can
+	// react to profile changes. Fire-and-forget: a publish failure must not
+	// block the user-facing response.
+	if m.eventPublisher != nil {
+		event := UserProfileUpdatedEvent{
+			UserID:    user.UserID,
+			Principal: user.UserID, // the JWT subject — identifies the caller
+			Metadata:  updatedUser.UserMetadata,
+			Timestamp: time.Now().UTC(),
+		}
+		if eventJSON, jsonErr := json.Marshal(event); jsonErr == nil {
+			if pubErr := m.eventPublisher.Publish(ctx, constants.UserProfileUpdatedSubject, eventJSON); pubErr != nil {
+				slog.WarnContext(ctx, "failed to publish user profile updated event",
+					"error", pubErr,
+					"user_id", user.UserID,
+				)
+			}
+		}
 	}
 
 	// Return success response with user metadata

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -458,13 +458,17 @@ func (m *messageHandlerOrchestrator) UpdateUser(ctx context.Context, msg port.Tr
 			Metadata:  updatedUser.UserMetadata,
 			Timestamp: time.Now().UTC(),
 		}
-		if eventJSON, jsonErr := json.Marshal(event); jsonErr == nil {
-			if pubErr := m.eventPublisher.Publish(ctx, constants.UserProfileUpdatedSubject, eventJSON); pubErr != nil {
-				slog.WarnContext(ctx, "failed to publish user profile updated event",
-					"error", pubErr,
-					"user_id", user.UserID,
-				)
-			}
+		eventJSON, jsonErr := json.Marshal(event)
+		if jsonErr != nil {
+			slog.WarnContext(ctx, "failed to marshal user profile updated event",
+				"error", jsonErr,
+				"user_id", user.UserID,
+			)
+		} else if pubErr := m.eventPublisher.Publish(ctx, constants.UserProfileUpdatedSubject, eventJSON); pubErr != nil {
+			slog.WarnContext(ctx, "failed to publish user profile updated event",
+				"error", pubErr,
+				"user_id", user.UserID,
+			)
 		}
 	}
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -112,7 +112,12 @@ func (m *messageHandlerOrchestrator) errorResponse(error string) []byte {
 		Success: false,
 		Error:   error,
 	}
-	responseJSON, _ := json.Marshal(response)
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		slog.Error("failed to marshal error response",
+			"error", err,
+		)
+	}
 	return responseJSON
 }
 

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -1293,7 +1293,10 @@ func TestMessageHandlerOrchestrator_UpdateUser_EventPublishing(t *testing.T) {
 				Name: converters.StringPtr("Test"),
 			},
 		}
-		data, _ := json.Marshal(inputUser)
+		data, err := json.Marshal(inputUser)
+		if err != nil {
+			t.Fatalf("failed to marshal input user: %v", err)
+		}
 		msg := &mockTransportMessenger{data: data}
 
 		result, err := orchestrator.UpdateUser(ctx, msg)
@@ -1331,10 +1334,16 @@ func TestMessageHandlerOrchestrator_UpdateUser_EventPublishing(t *testing.T) {
 				Name: converters.StringPtr("Test"),
 			},
 		}
-		data, _ := json.Marshal(inputUser)
+		data, err := json.Marshal(inputUser)
+		if err != nil {
+			t.Fatalf("failed to marshal input user: %v", err)
+		}
 		msg := &mockTransportMessenger{data: data}
 
-		orchestrator.UpdateUser(ctx, msg)
+		_, err = orchestrator.UpdateUser(ctx, msg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if len(publisher.calls) != 0 {
 			t.Errorf("expected no publish calls on update failure, got %d", len(publisher.calls))
@@ -1365,7 +1374,10 @@ func TestMessageHandlerOrchestrator_UpdateUser_EventPublishing(t *testing.T) {
 				Name: converters.StringPtr("Test"),
 			},
 		}
-		data, _ := json.Marshal(inputUser)
+		data, err := json.Marshal(inputUser)
+		if err != nil {
+			t.Fatalf("failed to marshal input user: %v", err)
+		}
 		msg := &mockTransportMessenger{data: data}
 
 		result, err := orchestrator.UpdateUser(ctx, msg)

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1168,6 +1169,218 @@ func TestMessageHandlerOrchestrator_UsernameToSub_NoUserReader(t *testing.T) {
 	if response.Error != "auth service unavailable" {
 		t.Errorf("Expected error 'auth service unavailable', got %s", response.Error)
 	}
+}
+
+// mockEventPublisher is a mock implementation of port.EventPublisher for testing
+type mockEventPublisher struct {
+	publishFunc func(ctx context.Context, subject string, data []byte) error
+	calls       []mockPublishCall
+}
+
+type mockPublishCall struct {
+	Subject string
+	Data    []byte
+}
+
+func (m *mockEventPublisher) Publish(ctx context.Context, subject string, data []byte) error {
+	m.calls = append(m.calls, mockPublishCall{Subject: subject, Data: data})
+	if m.publishFunc != nil {
+		return m.publishFunc(ctx, subject, data)
+	}
+	return nil
+}
+
+func TestMessageHandlerOrchestrator_UpdateUser_EventPublishing(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("publishes event with correct payload on successful update", func(t *testing.T) {
+		publisher := &mockEventPublisher{}
+		mockWriter := &mockUserServiceWriter{
+			updateUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{
+					UserID: user.UserID,
+					UserMetadata: &model.UserMetadata{
+						Name:     converters.StringPtr("Updated Name"),
+						JobTitle: converters.StringPtr("Engineer"),
+					},
+				}, nil
+			},
+		}
+
+		orchestrator := NewMessageHandlerOrchestrator(
+			WithUserWriterForMessageHandler(mockWriter),
+			WithEventPublisherForMessageHandler(publisher),
+		)
+
+		inputUser := &model.User{
+			Token:    "test-token",
+			Username: "testuser",
+			UserID:   "auth0|testuser",
+			UserMetadata: &model.UserMetadata{
+				Name: converters.StringPtr("Updated Name"),
+			},
+		}
+		data, _ := json.Marshal(inputUser)
+		msg := &mockTransportMessenger{data: data}
+
+		result, err := orchestrator.UpdateUser(ctx, msg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify the response is still successful
+		var response UserDataResponse
+		if err := json.Unmarshal(result, &response); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if !response.Success {
+			t.Errorf("expected success=true, got error: %s", response.Error)
+		}
+
+		// Verify event was published
+		if len(publisher.calls) != 1 {
+			t.Fatalf("expected 1 publish call, got %d", len(publisher.calls))
+		}
+		if publisher.calls[0].Subject != constants.UserProfileUpdatedSubject {
+			t.Errorf("expected subject %s, got %s", constants.UserProfileUpdatedSubject, publisher.calls[0].Subject)
+		}
+
+		// Verify event payload
+		var event UserProfileUpdatedEvent
+		if err := json.Unmarshal(publisher.calls[0].Data, &event); err != nil {
+			t.Fatalf("failed to unmarshal event: %v", err)
+		}
+		if event.UserID == "" {
+			t.Error("event user_id is empty")
+		}
+		if event.Principal == "" {
+			t.Error("event principal is empty")
+		}
+		if event.Metadata == nil {
+			t.Error("event metadata is nil")
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("event timestamp is zero")
+		}
+	})
+
+	t.Run("publish failure does not affect successful response", func(t *testing.T) {
+		publisher := &mockEventPublisher{
+			publishFunc: func(ctx context.Context, subject string, data []byte) error {
+				return fmt.Errorf("NATS connection lost")
+			},
+		}
+		mockWriter := &mockUserServiceWriter{
+			updateUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{
+					UserMetadata: &model.UserMetadata{
+						Name: converters.StringPtr("Test"),
+					},
+				}, nil
+			},
+		}
+
+		orchestrator := NewMessageHandlerOrchestrator(
+			WithUserWriterForMessageHandler(mockWriter),
+			WithEventPublisherForMessageHandler(publisher),
+		)
+
+		inputUser := &model.User{
+			Token:    "test-token",
+			Username: "testuser",
+			UserID:   "auth0|testuser",
+			UserMetadata: &model.UserMetadata{
+				Name: converters.StringPtr("Test"),
+			},
+		}
+		data, _ := json.Marshal(inputUser)
+		msg := &mockTransportMessenger{data: data}
+
+		result, err := orchestrator.UpdateUser(ctx, msg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var response UserDataResponse
+		if err := json.Unmarshal(result, &response); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if !response.Success {
+			t.Errorf("publish failure should not break the response, got error: %s", response.Error)
+		}
+	})
+
+	t.Run("no event published when update fails", func(t *testing.T) {
+		publisher := &mockEventPublisher{}
+		mockWriter := &mockUserServiceWriter{
+			updateUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return nil, errors.NewUnexpected("database error", nil)
+			},
+		}
+
+		orchestrator := NewMessageHandlerOrchestrator(
+			WithUserWriterForMessageHandler(mockWriter),
+			WithEventPublisherForMessageHandler(publisher),
+		)
+
+		inputUser := &model.User{
+			Token:    "test-token",
+			Username: "testuser",
+			UserID:   "auth0|testuser",
+			UserMetadata: &model.UserMetadata{
+				Name: converters.StringPtr("Test"),
+			},
+		}
+		data, _ := json.Marshal(inputUser)
+		msg := &mockTransportMessenger{data: data}
+
+		orchestrator.UpdateUser(ctx, msg)
+
+		if len(publisher.calls) != 0 {
+			t.Errorf("expected no publish calls on update failure, got %d", len(publisher.calls))
+		}
+	})
+
+	t.Run("no event published when publisher is nil", func(t *testing.T) {
+		mockWriter := &mockUserServiceWriter{
+			updateUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{
+					UserMetadata: &model.UserMetadata{
+						Name: converters.StringPtr("Test"),
+					},
+				}, nil
+			},
+		}
+
+		// No event publisher wired
+		orchestrator := NewMessageHandlerOrchestrator(
+			WithUserWriterForMessageHandler(mockWriter),
+		)
+
+		inputUser := &model.User{
+			Token:    "test-token",
+			Username: "testuser",
+			UserID:   "auth0|testuser",
+			UserMetadata: &model.UserMetadata{
+				Name: converters.StringPtr("Test"),
+			},
+		}
+		data, _ := json.Marshal(inputUser)
+		msg := &mockTransportMessenger{data: data}
+
+		result, err := orchestrator.UpdateUser(ctx, msg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var response UserDataResponse
+		if err := json.Unmarshal(result, &response); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if !response.Success {
+			t.Errorf("expected success without publisher, got error: %s", response.Error)
+		}
+	})
 }
 
 func TestNewMessageHandlerOrchestrator(t *testing.T) {

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -28,6 +28,15 @@ const (
 
 const (
 
+	// Domain event subjects (fire-and-forget, not request/reply)
+
+	// UserProfileUpdatedSubject is published after a successful user_metadata update.
+	// Consumers use this to sync profile changes to other systems (e.g. v1 platform DB).
+	UserProfileUpdatedSubject = "lfx.user_profile.updated"
+)
+
+const (
+
 	// User read/write subjects
 
 	// UserMetadataUpdateSubject is the subject for the user metadata update event.


### PR DESCRIPTION
## Summary

- Adds a `Publish()` method to `NATSClient` for fire-and-forget domain events
- Adds an `EventPublisher` port interface following the existing hexagonal architecture pattern
- After a successful `user_metadata.update`, publishes `lfx.user_profile.updated` with full `user_metadata` object + `user_id` + `principal` + timestamp
- Fire-and-forget: publish failure logs a warning but never blocks the user-facing response

**Event payload:**
```json
{
  "user_id": "auth0|jreyero",
  "principal": "auth0|jreyero",
  "user_metadata": { "given_name": "Joan", "family_name": "Reyero", ... },
  "timestamp": "2026-04-20T..."
}
```

**Consumer:** `lfx-v1-sync-helper` subscribes to this event to sync profile changes to the v1 platform DB via user-service.

## Files changed

| File | Change |
|------|--------|
| `internal/domain/port/event_publisher.go` | New `EventPublisher` interface |
| `internal/infrastructure/nats/client.go` | Add `Publish()` method |
| `pkg/constants/subjects.go` | Add `UserProfileUpdatedSubject` constant |
| `internal/service/message_handler.go` | Event struct + publish after `UpdateUser` succeeds |
| `cmd/server/service/providers.go` | Inject natsClient as event publisher |

## Test plan

- [ ] Deploy to dev, update a profile via v2 UI
- [ ] Verify event appears on `lfx.user_profile.updated` subject via `nats sub`
- [ ] Verify event contains full user_metadata, correct user_id and principal
- [ ] Verify publish failure doesn't break the user-facing metadata update response

🤖 Generated with [Claude Code](https://claude.com/claude-code)