### PR TITLE
feat(nats): replace Auth0 lookup in username_to_sub with local mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ module github.com/linuxfoundation/lfx-v2-auth-service
 go 1.25.0
 
 require (
+	github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f
 	github.com/auth0/go-auth0 v1.28.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
@@ -39,7 +40,6 @@ require (
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0 // indirect
-	github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f // indirect
 	github.com/aws/smithy-go v1.23.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0 // indirect
+	github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f // indirect
 	github.com/aws/smithy-go v1.23.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/PuerkitoBio/rehttp v1.4.0 h1:rIN7A2s+O9fmHUM1vUcInvlHj9Ysql4hE+Y0wcl/xk8=
 github.com/PuerkitoBio/rehttp v1.4.0/go.mod h1:LUwKPoDbDIA2RL5wYZCNsQ90cx4OJ4AWBmq6KzWZL1s=
+github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f h1:z8MkSJCUyTmW5YQlxsMLBlwA7GmjxC7L4ooicxqnhz8=
+github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f/go.mod h1:UdUwYgAXBiL+kLfcqxoQJYkHA/vl937/PbFhZM34aZs=
 github.com/auth0/go-auth0 v1.28.0 h1:yJULZamgYW95sxbAkSwQl9Q5n05XPxdxQ/wZRp5E7fY=
 github.com/auth0/go-auth0 v1.28.0/go.mod h1:uNoJKgkhEToRfN5zmHa0sC7btn0l6RrG4jx8q2/q43E=
 github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -180,24 +180,14 @@ func (m *messageHandlerOrchestrator) EmailToSub(ctx context.Context, msg port.Tr
 	return []byte(user.UserID), nil
 }
 
-// UsernameToSub converts a username to a sub
-func (m *messageHandlerOrchestrator) UsernameToSub(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
-
-	if m.userReader == nil {
-		return m.errorResponse("auth service unavailable"), nil
-	}
-
+// UsernameToSub converts a username to a sub using local mapping logic.
+// This derives the Auth0 sub deterministically without an external call.
+func (m *messageHandlerOrchestrator) UsernameToSub(_ context.Context, msg port.TransportMessenger) ([]byte, error) {
 	username := strings.TrimSpace(string(msg.Data()))
 	if username == "" {
 		return m.errorResponse("username is required"), nil
 	}
-
-	user := &model.User{Username: username}
-	user, err := m.userReader.SearchUser(ctx, user, constants.CriteriaTypeUsername)
-	if err != nil {
-		return m.errorResponse(err.Error()), nil
-	}
-	return []byte(user.UserID), nil
+	return []byte(mapUsernameToSub(username)), nil
 }
 
 func (m *messageHandlerOrchestrator) getUserByInput(ctx context.Context, msg port.TransportMessenger) (*model.User, error) {

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -938,57 +938,60 @@ func TestMessageHandlerOrchestrator_UsernameToSub(t *testing.T) {
 	tests := []struct {
 		name           string
 		messageData    []byte
-		userReader     *mockUserServiceReader
 		expectError    bool
 		expectedResult string
 		validateResult func(t *testing.T, result []byte)
 	}{
 		{
-			name:        "successful username to sub lookup",
-			messageData: []byte("zephyr.stormwind"),
-			userReader: &mockUserServiceReader{
-				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
-					if criteria != constants.CriteriaTypeUsername {
-						t.Errorf("Expected criteria %s, got %s", constants.CriteriaTypeUsername, criteria)
-					}
-					if user.Username != "zephyr.stormwind" {
-						t.Errorf("Expected username zephyr.stormwind, got %s", user.Username)
-					}
-					return &model.User{
-						UserID:   "auth0|zephyr001",
-						Username: "zephyr.stormwind",
-					}, nil
-				},
-			},
+			name:           "safe username maps directly",
+			messageData:    []byte("zephyr.stormwind"),
 			expectError:    false,
-			expectedResult: "auth0|zephyr001",
+			expectedResult: "auth0|zephyr.stormwind",
 		},
 		{
-			name:        "username with whitespace is trimmed",
-			messageData: []byte("  mauriciozanetti  "),
-			userReader: &mockUserServiceReader{
-				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
-					if user.Username != "mauriciozanetti" {
-						t.Errorf("Expected trimmed username mauriciozanetti, got %s", user.Username)
-					}
-					return &model.User{
-						UserID:   "auth0|mauricio001",
-						Username: "mauriciozanetti",
-					}, nil
-				},
-			},
+			name:           "safe username with whitespace is trimmed",
+			messageData:    []byte("  mauriciozanetti  "),
 			expectError:    false,
-			expectedResult: "auth0|mauricio001",
+			expectedResult: "auth0|mauriciozanetti",
+		},
+		{
+			name:           "safe username with hyphens and numbers",
+			messageData:    []byte("john-doe-42"),
+			expectError:    false,
+			expectedResult: "auth0|john-doe-42",
+		},
+		{
+			name:        "hex-like username is hashed",
+			messageData: []byte("abcdef1234567890abcdef12"),
+			expectError: false,
+			validateResult: func(t *testing.T, result []byte) {
+				sub := string(result)
+				if !strings.HasPrefix(sub, "auth0|") {
+					t.Errorf("Expected auth0| prefix, got %q", sub)
+				}
+				// Must not be the raw username — it was hashed
+				if sub == "auth0|abcdef1234567890abcdef12" {
+					t.Errorf("Expected hashed sub for hex username, got raw username in sub")
+				}
+			},
+		},
+		{
+			name:        "username with special chars is hashed",
+			messageData: []byte("user name@example"),
+			expectError: false,
+			validateResult: func(t *testing.T, result []byte) {
+				sub := string(result)
+				if !strings.HasPrefix(sub, "auth0|") {
+					t.Errorf("Expected auth0| prefix, got %q", sub)
+				}
+				if sub == "auth0|user name@example" {
+					t.Errorf("Expected hashed sub for unsafe username, got raw username in sub")
+				}
+			},
 		},
 		{
 			name:        "empty username returns error",
 			messageData: []byte(""),
-			userReader: &mockUserServiceReader{
-				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
-					t.Error("SearchUser should not be called for empty username")
-					return nil, errors.NewValidation("should not be called")
-				},
-			},
 			expectError: true,
 			validateResult: func(t *testing.T, result []byte) {
 				var response struct {
@@ -1009,12 +1012,6 @@ func TestMessageHandlerOrchestrator_UsernameToSub(t *testing.T) {
 		{
 			name:        "whitespace-only username returns error",
 			messageData: []byte("   "),
-			userReader: &mockUserServiceReader{
-				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
-					t.Error("SearchUser should not be called for whitespace-only username")
-					return nil, errors.NewValidation("should not be called")
-				},
-			},
 			expectError: true,
 			validateResult: func(t *testing.T, result []byte) {
 				var response struct {
@@ -1032,70 +1029,6 @@ func TestMessageHandlerOrchestrator_UsernameToSub(t *testing.T) {
 				}
 			},
 		},
-		{
-			name:        "user not found error",
-			messageData: []byte("nonexistent.user"),
-			userReader: &mockUserServiceReader{
-				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
-					return nil, errors.NewNotFound("user not found")
-				},
-			},
-			expectError: true,
-			validateResult: func(t *testing.T, result []byte) {
-				var response struct {
-					Success bool   `json:"success"`
-					Error   string `json:"error"`
-				}
-				if err := json.Unmarshal(result, &response); err != nil {
-					t.Fatalf("Failed to unmarshal error response: %v", err)
-				}
-				if response.Success {
-					t.Error("Expected success=false for user not found")
-				}
-				if response.Error != "user not found" {
-					t.Errorf("Expected error 'user not found', got %s", response.Error)
-				}
-			},
-		},
-		{
-			name:        "search service error",
-			messageData: []byte("service.error.user"),
-			userReader: &mockUserServiceReader{
-				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
-					return nil, errors.NewUnexpected("database connection failed", nil)
-				},
-			},
-			expectError: true,
-			validateResult: func(t *testing.T, result []byte) {
-				var response struct {
-					Success bool   `json:"success"`
-					Error   string `json:"error"`
-				}
-				if err := json.Unmarshal(result, &response); err != nil {
-					t.Fatalf("Failed to unmarshal error response: %v", err)
-				}
-				if response.Success {
-					t.Error("Expected success=false for service error")
-				}
-				if response.Error != "database connection failed" {
-					t.Errorf("Expected error 'database connection failed', got %s", response.Error)
-				}
-			},
-		},
-		{
-			name:        "user with empty sub",
-			messageData: []byte("empty.sub.user"),
-			userReader: &mockUserServiceReader{
-				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
-					return &model.User{
-						UserID:   "",
-						Username: "empty.sub.user",
-					}, nil
-				},
-			},
-			expectError:    false,
-			expectedResult: "", // Empty string is a valid response
-		},
 	}
 
 	for _, tt := range tests {
@@ -1104,9 +1037,7 @@ func TestMessageHandlerOrchestrator_UsernameToSub(t *testing.T) {
 				data: tt.messageData,
 			}
 
-			orchestrator := NewMessageHandlerOrchestrator(
-				WithUserReaderForMessageHandler(tt.userReader),
-			)
+			orchestrator := NewMessageHandlerOrchestrator()
 
 			result, err := orchestrator.UsernameToSub(ctx, mockMsg)
 
@@ -1120,11 +1051,9 @@ func TestMessageHandlerOrchestrator_UsernameToSub(t *testing.T) {
 				return
 			}
 
-			if tt.expectError {
-				if tt.validateResult != nil {
-					tt.validateResult(t, result)
-				}
-			} else {
+			if tt.validateResult != nil {
+				tt.validateResult(t, result)
+			} else if !tt.expectError {
 				actualResult := string(result)
 				if actualResult != tt.expectedResult {
 					t.Errorf("UsernameToSub() = %q, want %q", actualResult, tt.expectedResult)
@@ -1135,6 +1064,7 @@ func TestMessageHandlerOrchestrator_UsernameToSub(t *testing.T) {
 }
 
 func TestMessageHandlerOrchestrator_UsernameToSub_NoUserReader(t *testing.T) {
+	// UsernameToSub uses local mapping and does not require a userReader.
 	ctx := context.Background()
 
 	orchestrator := NewMessageHandlerOrchestrator()
@@ -1154,20 +1084,8 @@ func TestMessageHandlerOrchestrator_UsernameToSub_NoUserReader(t *testing.T) {
 		t.Fatal("UsernameToSub() returned nil result")
 	}
 
-	var response struct {
-		Success bool   `json:"success"`
-		Error   string `json:"error"`
-	}
-	if err := json.Unmarshal(result, &response); err != nil {
-		t.Fatalf("Failed to unmarshal error response: %v", err)
-	}
-
-	if response.Success {
-		t.Error("Expected success=false when user reader is nil")
-	}
-
-	if response.Error != "auth service unavailable" {
-		t.Errorf("Expected error 'auth service unavailable', got %s", response.Error)
+	if string(result) != "auth0|someuser" {
+		t.Errorf("UsernameToSub() = %q, want %q", string(result), "auth0|someuser")
 	}
 }
 

--- a/internal/service/username_mapping.go
+++ b/internal/service/username_mapping.go
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+// Username mapping utility for converting usernames to Auth0 "sub" format.
+//
+// This logic is derived from lfx-v1-sync-helper (cmd/lfx-v1-sync-helper/username_mapping.go)
+// and handles conversion of LDAP usernames to the "sub" claim format expected by v2 services.
+//
+// NOTE: This mapping is not forward-safe for a future Auth0 native-DB migration.
+// When that migration occurs, this will be replaced with a call to Auth0 with a cache layer.
+
+import (
+	"crypto/sha512"
+	"regexp"
+
+	"github.com/akamensky/base58"
+)
+
+var (
+	// safeNameRE detects usernames compatible with Auth0-generated user IDs.
+	safeNameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,58}[A-Za-z0-9]$`)
+	hexUserRE  = regexp.MustCompile(`^[0-9a-f]{24,60}$`)
+)
+
+// mapUsernameToSub converts a username to the Auth0 "sub" format expected by v2 services.
+//
+// The mapping logic:
+//   - Safe usernames (matching safeNameRE and not hexUserRE): use directly as userID
+//   - Unsafe usernames: hash with SHA-512 and encode to base58 (~80 chars)
+//
+// Returns: "auth0|{userID}" format string, or empty string if username is empty.
+func mapUsernameToSub(username string) string {
+	if username == "" {
+		return ""
+	}
+
+	var userID string
+	if safeNameRE.MatchString(username) && !hexUserRE.MatchString(username) {
+		userID = username
+	} else {
+		hash := sha512.Sum512([]byte(username))
+		userID = base58.Encode(hash[:])
+	}
+
+	return "auth0|" + userID
+}


### PR DESCRIPTION
## Summary

- Replaces the `SearchUser` Auth0 call in the `username_to_sub` NATS handler with a deterministic local mapping (safe username passthrough, or SHA-512+base58 hash for unsafe usernames)
- Copies mapping logic from `lfx-v1-sync-helper/cmd/lfx-v1-sync-helper/username_mapping.go` into `internal/service/username_mapping.go`
- Handler no longer requires a live Auth0/userReader connection for this path
- Adds `github.com/akamensky/base58` dependency

**Note:** This approach is not forward-safe for a future Auth0 native-DB migration — that will be addressed when we switch this back to call Auth0 with a cache layer.

## Test plan

- [ ] `go test ./internal/service/... -run TestMessageHandlerOrchestrator_UsernameToSub` — all 8 cases pass
- [ ] Safe username passthrough: `zephyr.stormwind` → `auth0|zephyr.stormwind`
- [ ] Hex-like username hashed: `abcdef1234567890abcdef12` → `auth0|<base58hash>`
- [ ] Special-char username hashed
- [ ] Whitespace trimming still works
- [ ] Empty/whitespace-only username still returns error

Closes LFXV2-1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)