### PR TITLE
feat: exclude health endpoints from tracing

### DIFF
--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -65,7 +65,7 @@ func handleHTTPServer(ctx context.Context, host string, authEndpoints *authservi
 	handler = otelhttp.NewHandler(handler, "auth-service",
 		otelhttp.WithFilter(func(r *http.Request) bool {
 			p := r.URL.Path
-			return p != "/healthz" && p != "/livez" && p != "/readyz"
+			return p != authserver.LivezAuthServicePath() && p != authserver.ReadyzAuthServicePath()
 		}),
 	)
 

--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -62,7 +62,12 @@ func handleHTTPServer(ctx context.Context, host string, authEndpoints *authservi
 		handler = debug.HTTP()(handler)
 	}
 	// Wrap the handler with OpenTelemetry instrumentation
-	handler = otelhttp.NewHandler(handler, "auth-service")
+	handler = otelhttp.NewHandler(handler, "auth-service",
+		otelhttp.WithFilter(func(r *http.Request) bool {
+			p := r.URL.Path
+			return p != "/healthz" && p != "/livez" && p != "/readyz"
+		}),
+	)
 
 	// Start HTTP server using default configuration, change the code to
 	// configure the server as required by your service.


### PR DESCRIPTION
## Summary

- Add `otelhttp.WithFilter` to `otelhttp.NewHandler` to skip span creation for `/healthz`, `/livez`, and `/readyz` Kubernetes probe endpoints
- Reduces high-volume, low-value trace noise from liveness/readiness probes

## Test plan

- [x] `go build ./...` passes

Issue: LFXV2-1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)