### PR TITLE
fix(otel): honor parent span sampling decisions

### DIFF
--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -79,10 +79,11 @@ spec:
             value: {{ $otelTracesExporter | quote }}
           {{- end }}
           {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
+          {{- $otelTracesSamplerNormalized := $otelTracesSampler | lower }}
           {{- if ne $otelTracesSampler "" }}
           - name: OTEL_TRACES_SAMPLER
             value: {{ $otelTracesSampler | quote }}
-          {{- if or (eq $otelTracesSampler "traceidratio") (eq $otelTracesSampler "parentbased_traceidratio") }}
+          {{- if or (eq $otelTracesSamplerNormalized "traceidratio") (eq $otelTracesSamplerNormalized "parentbased_traceidratio") }}
           {{- $otelTracesSamplerArg := .Values.app.otel.tracesSamplerArg | toString | trim }}
           {{- if ne $otelTracesSamplerArg "" }}
           - name: OTEL_TRACES_SAMPLER_ARG

--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -78,11 +78,6 @@ spec:
           - name: OTEL_TRACES_EXPORTER
             value: {{ $otelTracesExporter | quote }}
           {{- end }}
-          {{- $otelTracesSampleRatio := .Values.app.otel.tracesSampleRatio | toString | trim }}
-          {{- if ne $otelTracesSampleRatio "" }}
-          - name: OTEL_TRACES_SAMPLE_RATIO
-            value: {{ $otelTracesSampleRatio | quote }}
-          {{- end }}
           {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
           {{- if ne $otelTracesSampler "" }}
           - name: OTEL_TRACES_SAMPLER

--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -87,9 +87,12 @@ spec:
           {{- if ne $otelTracesSampler "" }}
           - name: OTEL_TRACES_SAMPLER
             value: {{ $otelTracesSampler | quote }}
-          {{- if ne $otelTracesSampleRatio "" }}
+          {{- if or (eq $otelTracesSampler "traceidratio") (eq $otelTracesSampler "parentbased_traceidratio") }}
+          {{- $otelTracesSamplerArg := .Values.app.otel.tracesSamplerArg | toString | trim }}
+          {{- if ne $otelTracesSamplerArg "" }}
           - name: OTEL_TRACES_SAMPLER_ARG
-            value: {{ $otelTracesSampleRatio | quote }}
+            value: {{ $otelTracesSamplerArg | quote }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}

--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -83,6 +83,15 @@ spec:
           - name: OTEL_TRACES_SAMPLE_RATIO
             value: {{ $otelTracesSampleRatio | quote }}
           {{- end }}
+          {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
+          {{- if ne $otelTracesSampler "" }}
+          - name: OTEL_TRACES_SAMPLER
+            value: {{ $otelTracesSampler | quote }}
+          {{- if ne $otelTracesSampleRatio "" }}
+          - name: OTEL_TRACES_SAMPLER_ARG
+            value: {{ $otelTracesSampleRatio | quote }}
+          {{- end }}
+          {{- end }}
           {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
           {{- if ne $otelMetricsExporter "" }}
           - name: OTEL_METRICS_EXPORTER

--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -79,17 +79,14 @@ spec:
             value: {{ $otelTracesExporter | quote }}
           {{- end }}
           {{- $otelTracesSampler := .Values.app.otel.tracesSampler | toString | trim }}
-          {{- $otelTracesSamplerNormalized := $otelTracesSampler | lower }}
           {{- if ne $otelTracesSampler "" }}
           - name: OTEL_TRACES_SAMPLER
             value: {{ $otelTracesSampler | quote }}
-          {{- if or (eq $otelTracesSamplerNormalized "traceidratio") (eq $otelTracesSamplerNormalized "parentbased_traceidratio") }}
+          {{- end }}
           {{- $otelTracesSamplerArg := .Values.app.otel.tracesSamplerArg | toString | trim }}
           {{- if ne $otelTracesSamplerArg "" }}
           - name: OTEL_TRACES_SAMPLER_ARG
             value: {{ $otelTracesSamplerArg | quote }}
-          {{- end }}
-          {{- end }}
           {{- end }}
           {{- $otelMetricsExporter := .Values.app.otel.metricsExporter | toString | trim }}
           {{- if ne $otelMetricsExporter "" }}

--- a/charts/lfx-v2-auth-service/values.yaml
+++ b/charts/lfx-v2-auth-service/values.yaml
@@ -191,6 +191,11 @@ app:
     # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
     # (default: "1.0")
     tracesSampleRatio: "1.0"
+    # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
+    # "always_on", "always_off", "traceidratio", "parentbased_always_on",
+    # "parentbased_always_off", "parentbased_traceidratio".
+    # When empty, the application defaults to parentbased_traceidratio.
+    tracesSampler: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/charts/lfx-v2-auth-service/values.yaml
+++ b/charts/lfx-v2-auth-service/values.yaml
@@ -187,10 +187,6 @@ app:
     # tracesExporter specifies the traces exporter: "otlp" or "none"
     # (default: "none")
     tracesExporter: "none"
-    # tracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0)
-    # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
-    # (default: "1.0")
-    tracesSampleRatio: "1.0"
     # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
     # "always_on", "always_off", "traceidratio", "parentbased_always_on",
     # "parentbased_always_off", "parentbased_traceidratio".
@@ -198,7 +194,6 @@ app:
     tracesSampler: ""
     # tracesSamplerArg specifies the argument for ratio-based samplers (0.0 to 1.0).
     # Only used with traceidratio or parentbased_traceidratio samplers.
-    # When empty, defaults to tracesSampleRatio.
     tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")

--- a/charts/lfx-v2-auth-service/values.yaml
+++ b/charts/lfx-v2-auth-service/values.yaml
@@ -196,6 +196,10 @@ app:
     # "parentbased_always_off", "parentbased_traceidratio".
     # When empty, the application defaults to parentbased_traceidratio.
     tracesSampler: ""
+    # tracesSamplerArg specifies the argument for ratio-based samplers (0.0 to 1.0).
+    # Only used with traceidratio or parentbased_traceidratio samplers.
+    # When empty, defaults to tracesSampleRatio.
+    tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -67,6 +67,12 @@ type OTelConfig struct {
 	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
 	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
 	TracesSampleRatio float64
+	// TracesSampler specifies the sampler to use for traces.
+	// Env: OTEL_TRACES_SAMPLER (default: "")
+	TracesSampler string
+	// TracesSamplerArg specifies the argument for the sampler.
+	// Env: OTEL_TRACES_SAMPLER_ARG (default: "")
+	TracesSamplerArg string
 	// MetricsExporter specifies the metrics exporter: "otlp" or "none".
 	// Env: OTEL_METRICS_EXPORTER (default: "none")
 	MetricsExporter string
@@ -128,6 +134,9 @@ func OTelConfigFromEnv() OTelConfig {
 		}
 	}
 
+	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
+	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
+
 	propagators := os.Getenv("OTEL_PROPAGATORS")
 	if propagators == "" {
 		propagators = "tracecontext,baggage,jaeger"
@@ -141,6 +150,8 @@ func OTelConfigFromEnv() OTelConfig {
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
 		"traces-sample-ratio", tracesSampleRatio,
+		"traces-sampler", tracesSampler,
+		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
 		"logs-exporter", logsExporter,
 		"propagators", propagators,
@@ -154,6 +165,8 @@ func OTelConfigFromEnv() OTelConfig {
 		Insecure:          insecure,
 		TracesExporter:    tracesExporter,
 		TracesSampleRatio: tracesSampleRatio,
+		TracesSampler:     tracesSampler,
+		TracesSamplerArg:  tracesSamplerArg,
 		MetricsExporter:   metricsExporter,
 		LogsExporter:      logsExporter,
 		Propagators:       propagators,
@@ -303,26 +316,23 @@ func endpointURL(raw string, insecure bool) string {
 	return "https://" + raw
 }
 
-// newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
-// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
-// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
-// This ensures parent span sampling decisions are always honored.
+// newSampler creates a trace.Sampler based on OTelConfig sampler settings.
+// It supports both standard OTEL samplers and parent-based variants,
+// defaulting to parentbased_traceidratio for consistency with W3C TraceContext.
 func newSampler(cfg OTelConfig) trace.Sampler {
-	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
-	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
-
 	parseRatio := func() float64 {
-		if arg != "" {
-			r, err := strconv.ParseFloat(arg, 64)
+		if cfg.TracesSamplerArg != "" {
+			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
+				"provided-value", cfg.TracesSamplerArg, "error", err)
 		}
 		return cfg.TracesSampleRatio
 	}
 
-	switch sampler {
+	switch cfg.TracesSampler {
 	case "always_on":
 		return trace.AlwaysSample()
 	case "always_off":
@@ -335,8 +345,12 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 		return trace.ParentBased(trace.NeverSample())
 	case "parentbased_traceidratio":
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
-	default: // empty/unknown → parent-based with configured ratio
-		return trace.ParentBased(trace.TraceIDRatioBased(cfg.TracesSampleRatio))
+	default:
+		if cfg.TracesSampler != "" {
+			slog.Warn("unknown OTEL_TRACES_SAMPLER, falling back to parentbased_traceidratio",
+				"provided-value", cfg.TracesSampler, "fallback-ratio", cfg.TracesSampleRatio)
+		}
+		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	}
 }
 

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -63,10 +63,6 @@ type OTelConfig struct {
 	// TracesExporter specifies the traces exporter: "otlp" or "none".
 	// Env: OTEL_TRACES_EXPORTER (default: "none")
 	TracesExporter string
-	// TracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0).
-	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
-	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
-	TracesSampleRatio float64
 	// TracesSampler specifies the sampler to use for traces.
 	// Env: OTEL_TRACES_SAMPLER (default: "")
 	TracesSampler string
@@ -119,21 +115,6 @@ func OTelConfigFromEnv() OTelConfig {
 		logsExporter = OTelExporterNone
 	}
 
-	tracesSampleRatio := 1.0
-	if ratio := os.Getenv("OTEL_TRACES_SAMPLE_RATIO"); ratio != "" {
-		if parsed, err := strconv.ParseFloat(ratio, 64); err == nil {
-			if parsed >= 0.0 && parsed <= 1.0 {
-				tracesSampleRatio = parsed
-			} else {
-				slog.Warn("OTEL_TRACES_SAMPLE_RATIO must be between 0.0 and 1.0, using default 1.0",
-					"provided-value", ratio)
-			}
-		} else {
-			slog.Warn("invalid OTEL_TRACES_SAMPLE_RATIO value, using default 1.0",
-				"provided-value", ratio, "error", err)
-		}
-	}
-
 	tracesSampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
 	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
 
@@ -149,7 +130,6 @@ func OTelConfigFromEnv() OTelConfig {
 		"endpoint", endpoint,
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
-		"traces-sample-ratio", tracesSampleRatio,
 		"traces-sampler", tracesSampler,
 		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
@@ -158,18 +138,17 @@ func OTelConfigFromEnv() OTelConfig {
 	).Debug("OTelConfig")
 
 	return OTelConfig{
-		ServiceName:       serviceName,
-		ServiceVersion:    serviceVersion,
-		Protocol:          protocol,
-		Endpoint:          endpoint,
-		Insecure:          insecure,
-		TracesExporter:    tracesExporter,
-		TracesSampleRatio: tracesSampleRatio,
-		TracesSampler:     tracesSampler,
-		TracesSamplerArg:  tracesSamplerArg,
-		MetricsExporter:   metricsExporter,
-		LogsExporter:      logsExporter,
-		Propagators:       propagators,
+		ServiceName:      serviceName,
+		ServiceVersion:   serviceVersion,
+		Protocol:         protocol,
+		Endpoint:         endpoint,
+		Insecure:         insecure,
+		TracesExporter:   tracesExporter,
+		TracesSampler:    tracesSampler,
+		TracesSamplerArg: tracesSamplerArg,
+		MetricsExporter:  metricsExporter,
+		LogsExporter:     logsExporter,
+		Propagators:      propagators,
 	}
 }
 
@@ -326,10 +305,10 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
 				"provided-value", cfg.TracesSamplerArg, "error", err)
 		}
-		return cfg.TracesSampleRatio
+		return 1.0
 	}
 
 	switch cfg.TracesSampler {
@@ -348,7 +327,7 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 	default:
 		if cfg.TracesSampler != "" {
 			slog.Warn("unknown OTEL_TRACES_SAMPLER, falling back to parentbased_traceidratio",
-				"provided-value", cfg.TracesSampler, "fallback-ratio", cfg.TracesSampleRatio)
+				"provided-value", cfg.TracesSampler)
 		}
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	}

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -303,6 +303,43 @@ func endpointURL(raw string, insecure bool) string {
 	return "https://" + raw
 }
 
+// newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
+// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
+// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
+// This ensures parent span sampling decisions are always honored.
+func newSampler(cfg OTelConfig) trace.Sampler {
+	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
+	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+
+	parseRatio := func() float64 {
+		if arg != "" {
+			r, err := strconv.ParseFloat(arg, 64)
+			if err == nil && r >= 0.0 && r <= 1.0 {
+				return r
+			}
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+		}
+		return cfg.TracesSampleRatio
+	}
+
+	switch sampler {
+	case "always_on":
+		return trace.AlwaysSample()
+	case "always_off":
+		return trace.NeverSample()
+	case "traceidratio":
+		return trace.TraceIDRatioBased(parseRatio())
+	case "parentbased_always_on":
+		return trace.ParentBased(trace.AlwaysSample())
+	case "parentbased_always_off":
+		return trace.ParentBased(trace.NeverSample())
+	case "parentbased_traceidratio":
+		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
+	default: // empty/unknown → parent-based with configured ratio
+		return trace.ParentBased(trace.TraceIDRatioBased(cfg.TracesSampleRatio))
+	}
+}
+
 // newTraceProvider creates a TracerProvider with an OTLP exporter configured based on the protocol setting.
 func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resource) (*trace.TracerProvider, error) {
 	var exporter trace.SpanExporter
@@ -334,7 +371,7 @@ func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resourc
 
 	traceProvider := trace.NewTracerProvider(
 		trace.WithResource(res),
-		trace.WithSampler(trace.TraceIDRatioBased(cfg.TracesSampleRatio)),
+		trace.WithSampler(newSampler(cfg)),
 		trace.WithBatcher(exporter,
 			trace.WithBatchTimeout(time.Second),
 		),

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -300,15 +300,21 @@ func endpointURL(raw string, insecure bool) string {
 // defaulting to parentbased_traceidratio for consistency with W3C TraceContext.
 func newSampler(cfg OTelConfig) trace.Sampler {
 	parseRatio := func() float64 {
-		if cfg.TracesSamplerArg != "" {
-			r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
-			if err == nil && r >= 0.0 && r <= 1.0 {
-				return r
-			}
+		if cfg.TracesSamplerArg == "" {
+			return 1.0
+		}
+		r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
+		if err != nil {
 			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
 				"provided-value", cfg.TracesSamplerArg, "error", err)
+			return 1.0
 		}
-		return 1.0
+		if r < 0.0 || r > 1.0 {
+			slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
+				"provided-value", cfg.TracesSamplerArg)
+			return 1.0
+		}
+		return r
 	}
 
 	switch cfg.TracesSampler {

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -5,8 +5,10 @@ package utils
 
 import (
 	"context"
-
 	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // TestOTelConfigFromEnv_Defaults verifies that OTelConfigFromEnv returns
@@ -524,7 +526,6 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 // supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
 func TestNewSampler(t *testing.T) {
 	cfg := OTelConfig{TracesSampleRatio: 0.5}
-
 	tests := []struct {
 		name    string
 		sampler string
@@ -539,15 +540,17 @@ func TestNewSampler(t *testing.T) {
 		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
 		{"unknown", "unknown", ""},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
-			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
-
-			s := newSampler(cfg)
+			c := cfg
+			c.TracesSampler = tt.sampler
+			c.TracesSamplerArg = tt.arg
+			s := newSampler(c)
 			if s == nil {
-				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+				t.Fatalf("newSampler(%q) returned nil", tt.sampler)
+			}
+			if s.Description() == "" {
+				t.Errorf("newSampler(%q).Description() is empty", tt.sampler)
 			}
 		})
 	}
@@ -556,12 +559,28 @@ func TestNewSampler(t *testing.T) {
 // TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
 // falls back to cfg.TracesSampleRatio without panicking.
 func TestNewSampler_InvalidArg(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
-	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
-	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
-
+	cfg := OTelConfig{
+		TracesSampleRatio: 0.5,
+		TracesSampler:     "parentbased_traceidratio",
+		TracesSamplerArg:  "invalid",
+	}
 	s := newSampler(cfg)
 	if s == nil {
-		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+		t.Fatal("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+}
+
+// TestNewSampler_ParentHonored verifies that parent-based samplers
+// correctly honor parent span sampling decisions.
+func TestNewSampler_ParentHonored(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 1.0}
+	s := newSampler(cfg) // default = parentbased_traceidratio
+
+	// With a sampled parent, child should also be sampled
+	sampledParent := oteltrace.SpanContext{}.WithTraceFlags(oteltrace.FlagsSampled)
+	parentCtx := oteltrace.ContextWithRemoteSpanContext(context.Background(), sampledParent)
+	result := s.ShouldSample(trace.SamplingParameters{ParentContext: parentCtx})
+	if result.Decision != trace.RecordAndSample {
+		t.Errorf("expected RecordAndSample with sampled parent, got %v", result.Decision)
 	}
 }

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -519,3 +519,49 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 
 	_ = shutdown(ctx)
 }
+
+// TestNewSampler verifies that newSampler returns a non-nil sampler for all
+// supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
+func TestNewSampler(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+
+	tests := []struct {
+		name    string
+		sampler string
+		arg     string
+	}{
+		{"default (empty)", "", ""},
+		{"always_on", "always_on", ""},
+		{"always_off", "always_off", ""},
+		{"traceidratio", "traceidratio", "0.5"},
+		{"parentbased_always_on", "parentbased_always_on", ""},
+		{"parentbased_always_off", "parentbased_always_off", ""},
+		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
+		{"unknown", "unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
+			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
+
+			s := newSampler(cfg)
+			if s == nil {
+				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+			}
+		})
+	}
+}
+
+// TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
+// falls back to cfg.TracesSampleRatio without panicking.
+func TestNewSampler_InvalidArg(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
+
+	s := newSampler(cfg)
+	if s == nil {
+		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+}

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/sdk/trace"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // TestOTelConfigFromEnv_Defaults verifies that OTelConfigFromEnv returns
@@ -528,13 +527,27 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 // TestNewSampler_ParentHonored verifies that parent-based samplers
 // correctly honor parent span sampling decisions.
 func TestNewSampler_ParentHonored(t *testing.T) {
-	cfg := OTelConfig{}
+	cfg := OTelConfig{
+		TracesSampler:    "parentbased_traceidratio",
+		TracesSamplerArg: "0.0",
+	}
 	s := newSampler(cfg) // default = parentbased_traceidratio
 
-	// With a sampled parent, child should also be sampled
-	sampledParent := oteltrace.SpanContext{}.WithTraceFlags(oteltrace.FlagsSampled)
-	parentCtx := oteltrace.ContextWithRemoteSpanContext(context.Background(), sampledParent)
-	result := s.ShouldSample(trace.SamplingParameters{ParentContext: parentCtx})
+	// Without parent, ratio=0.0 should drop.
+	result := s.ShouldSample(trace.SamplingParameters{ParentContext: context.Background()})
+	if result.Decision != trace.Drop {
+		t.Errorf("expected Drop without parent at ratio 0.0, got %v", result.Decision)
+	}
+
+	// With a sampled parent span (created via tracer), child should also be sampled
+	// even though ratio=0.0, because parent-based sampler honors the parent's decision.
+	tp := trace.NewTracerProvider(trace.WithSampler(trace.AlwaysSample()))
+	defer tp.ForceFlush(context.Background())
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "parent")
+	defer span.End()
+
+	result = s.ShouldSample(trace.SamplingParameters{ParentContext: ctx})
 	if result.Decision != trace.RecordAndSample {
 		t.Errorf("expected RecordAndSample with sampled parent, got %v", result.Decision)
 	}

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -131,12 +131,12 @@ func TestOTelConfigFromEnv_InsecureFlag(t *testing.T) {
 // disabled, and that the returned shutdown function works correctly.
 func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:    "test-service",
-		ServiceVersion: "1.0.0",
-		Protocol:       OTelProtocolGRPC,
-		TracesExporter: OTelExporterNone,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		TracesExporter:  OTelExporterNone,
 		MetricsExporter: OTelExporterNone,
-		LogsExporter:   OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -162,12 +162,12 @@ func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 // graceful shutdown scenarios where shutdown may be triggered multiple times.
 func TestSetupOTelSDKWithConfig_ShutdownIdempotent(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:    "test-service",
-		ServiceVersion: "1.0.0",
-		Protocol:       OTelProtocolGRPC,
-		TracesExporter: OTelExporterNone,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		TracesExporter:  OTelExporterNone,
 		MetricsExporter: OTelExporterNone,
-		LogsExporter:   OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
 	}
 
 	ctx := context.Background()

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -34,9 +34,6 @@ func TestOTelConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.TracesExporter != OTelExporterNone {
 		t.Errorf("expected default TracesExporter %q, got %q", OTelExporterNone, cfg.TracesExporter)
 	}
-	if cfg.TracesSampleRatio != 1.0 {
-		t.Errorf("expected default TracesSampleRatio 1.0, got %f", cfg.TracesSampleRatio)
-	}
 	if cfg.MetricsExporter != OTelExporterNone {
 		t.Errorf("expected default MetricsExporter %q, got %q", OTelExporterNone, cfg.MetricsExporter)
 	}
@@ -54,7 +51,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4318")
 	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
 	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
-	t.Setenv("OTEL_TRACES_SAMPLE_RATIO", "0.5")
 	t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
 	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
 
@@ -78,9 +74,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	if cfg.TracesExporter != OTelExporterOTLP {
 		t.Errorf("expected TracesExporter %q, got %q", OTelExporterOTLP, cfg.TracesExporter)
 	}
-	if cfg.TracesSampleRatio != 0.5 {
-		t.Errorf("expected TracesSampleRatio 0.5, got %f", cfg.TracesSampleRatio)
-	}
 	if cfg.MetricsExporter != OTelExporterOTLP {
 		t.Errorf("expected MetricsExporter %q, got %q", OTelExporterOTLP, cfg.MetricsExporter)
 	}
@@ -98,40 +91,6 @@ func TestOTelConfigFromEnv_UnsupportedProtocol(t *testing.T) {
 
 	if cfg.Protocol != "unsupported" {
 		t.Errorf("expected Protocol 'unsupported', got %q", cfg.Protocol)
-	}
-}
-
-// TestOTelConfigFromEnv_TracesSampleRatio tests the parsing and validation of
-// the OTEL_TRACES_SAMPLE_RATIO environment variable, including edge cases like
-// invalid values, out-of-range numbers, and empty strings.
-func TestOTelConfigFromEnv_TracesSampleRatio(t *testing.T) {
-	tests := []struct {
-		name          string
-		envValue      string
-		expectedRatio float64
-	}{
-		{"valid zero", "0.0", 0.0},
-		{"valid half", "0.5", 0.5},
-		{"valid one", "1.0", 1.0},
-		{"valid small", "0.01", 0.01},
-		{"invalid negative", "-0.5", 1.0},      // defaults to 1.0
-		{"invalid above one", "1.5", 1.0},      // defaults to 1.0
-		{"invalid non-number", "invalid", 1.0}, // defaults to 1.0
-		{"empty string", "", 1.0},              // defaults to 1.0
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
-				t.Setenv("OTEL_TRACES_SAMPLE_RATIO", tt.envValue)
-			}
-
-			cfg := OTelConfigFromEnv()
-
-			if cfg.TracesSampleRatio != tt.expectedRatio {
-				t.Errorf("expected TracesSampleRatio %f, got %f", tt.expectedRatio, cfg.TracesSampleRatio)
-			}
-		})
 	}
 }
 
@@ -172,13 +131,12 @@ func TestOTelConfigFromEnv_InsecureFlag(t *testing.T) {
 // disabled, and that the returned shutdown function works correctly.
 func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		TracesExporter:    OTelExporterNone,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Protocol:       OTelProtocolGRPC,
+		TracesExporter: OTelExporterNone,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:   OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -204,13 +162,12 @@ func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 // graceful shutdown scenarios where shutdown may be triggered multiple times.
 func TestSetupOTelSDKWithConfig_ShutdownIdempotent(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		TracesExporter:    OTelExporterNone,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Protocol:       OTelProtocolGRPC,
+		TracesExporter: OTelExporterNone,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:   OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -497,16 +454,15 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "127.0.0.1:4317")
 
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		Endpoint:          "127.0.0.1:4317",
-		Insecure:          true,
-		TracesExporter:    OTelExporterOTLP,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
-		Propagators:       "tracecontext,baggage",
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		Endpoint:        "127.0.0.1:4317",
+		Insecure:        true,
+		TracesExporter:  OTelExporterOTLP,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
+		Propagators:     "tracecontext,baggage",
 	}
 
 	ctx := context.Background()
@@ -525,7 +481,7 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 // TestNewSampler verifies that newSampler returns a non-nil sampler for all
 // supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
 func TestNewSampler(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	cfg := OTelConfig{}
 	tests := []struct {
 		name    string
 		sampler string
@@ -557,12 +513,11 @@ func TestNewSampler(t *testing.T) {
 }
 
 // TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
-// falls back to cfg.TracesSampleRatio without panicking.
+// defaults to 1.0 without panicking.
 func TestNewSampler_InvalidArg(t *testing.T) {
 	cfg := OTelConfig{
-		TracesSampleRatio: 0.5,
-		TracesSampler:     "parentbased_traceidratio",
-		TracesSamplerArg:  "invalid",
+		TracesSampler:    "parentbased_traceidratio",
+		TracesSamplerArg: "invalid",
 	}
 	s := newSampler(cfg)
 	if s == nil {
@@ -573,7 +528,7 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 // TestNewSampler_ParentHonored verifies that parent-based samplers
 // correctly honor parent span sampling decisions.
 func TestNewSampler_ParentHonored(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 1.0}
+	cfg := OTelConfig{}
 	s := newSampler(cfg) // default = parentbased_traceidratio
 
 	// With a sampled parent, child should also be sampled

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -542,7 +542,11 @@ func TestNewSampler_ParentHonored(t *testing.T) {
 	// With a sampled parent span (created via tracer), child should also be sampled
 	// even though ratio=0.0, because parent-based sampler honors the parent's decision.
 	tp := trace.NewTracerProvider(trace.WithSampler(trace.AlwaysSample()))
-	defer tp.ForceFlush(context.Background())
+	defer func() {
+		if err := tp.ForceFlush(context.Background()); err != nil {
+			t.Logf("ForceFlush error: %v", err)
+		}
+	}()
 	tracer := tp.Tracer("test")
 	ctx, span := tracer.Start(context.Background(), "parent")
 	defer span.End()


### PR DESCRIPTION
## Summary

Fixes LFXV2-1734 — all Go service spans have \`parentid: 0\` in Datadog because \`TraceIDRatioBased\` makes independent sampling decisions, ignoring incoming \`traceparent\` headers.

## Changes

**\`pkg/utils/otel.go\`** — Replace bare \`trace.TraceIDRatioBased(ratio)\` with a new \`newSampler(cfg)\` function that:
- Reads \`OTEL_TRACES_SAMPLER\` / \`OTEL_TRACES_SAMPLER_ARG\` (standard OTel env vars)
- Defaults to \`parentbased_traceidratio\` with ratio \`1.0\` when unset
- Supports all 6 OTel sampler types: \`always_on\`, \`always_off\`, \`traceidratio\`, \`parentbased_always_on\`, \`parentbased_always_off\`, \`parentbased_traceidratio\`
- Removes \`TracesSampleRatio\` / \`OTEL_TRACES_SAMPLE_RATIO\` entirely — no backward compatibility fallback; configure sampling via \`OTEL_TRACES_SAMPLER_ARG\`

**\`pkg/utils/otel_test.go\`** — Added \`TestNewSampler\`, \`TestNewSampler_InvalidArg\`, and \`TestNewSampler_ParentHonored\`

**\`charts/lfx-v2-auth-service/templates/deployment.yaml\`** — Renders \`OTEL_TRACES_SAMPLER\` when \`app.otel.tracesSampler\` is non-empty; renders \`OTEL_TRACES_SAMPLER_ARG\` when \`app.otel.tracesSamplerArg\` is non-empty (independent conditions)

**\`charts/lfx-v2-auth-service/values.yaml\`** — Added \`tracesSampler: ""\` and \`tracesSamplerArg: ""\` to \`app.otel\`

## Why

\`TraceIDRatioBased\` re-decides sampling per span regardless of the parent's sampling flag. Wrapping with \`parentbased_traceidratio\` ensures child spans always follow the parent's decision, restoring end-to-end trace continuity.

\`OTEL_TRACES_SAMPLER_ARG\` replaces the old \`OTEL_TRACES_SAMPLE_RATIO\` / \`TracesSampleRatio\` mechanism. All deployments have been updated in ArgoCD values to use \`tracesSamplerArg\` directly. No backward compatibility fallback is provided.

Issue: LFXV2-1734