### PR TITLE
[LFXV2-FIX] Always create ServiceAccount to fix FailedMount on mode switch

### DIFF
--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -26,9 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if eq .Values.app.environment.USER_REPOSITORY_TYPE.value "authelia" }}
       serviceAccountName: {{ .Chart.Name }}
-      {{- end }}
       containers:
         - name: app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lfx-v2-auth-service/templates/serviceaccount.yaml
+++ b/charts/lfx-v2-auth-service/templates/serviceaccount.yaml
@@ -1,6 +1,5 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
-{{- if eq .Values.app.environment.USER_REPOSITORY_TYPE.value "authelia" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -13,4 +12,3 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}


### PR DESCRIPTION
## Summary

- Remove the `authelia`-only gate from `serviceaccount.yaml` so the `lfx-v2-auth-service` ServiceAccount is always created
- Remove the conditional `serviceAccountName` from `deployment.yaml` so it is always explicitly set
- Role and RoleBinding (Authelia ConfigMap/Secret/DaemonSet permissions) remain gated on `authelia` mode — no extra RBAC for `mock` or `auth0`

## Root Cause

When switching `USER_REPOSITORY_TYPE` from `authelia` to `mock`, Helm's three-way strategic merge patch did not remove the `serviceAccountName` field from the Deployment pod spec because the field was simply absent from the new template (not explicitly nulled). As a result:

1. The SA (`lfx-v2-auth-service`) was deleted by Helm (no longer in templates)
2. The Deployment pod spec **still** referenced `lfx-v2-auth-service` SA
3. Every new pod failed with: `MountVolume.SetUp failed for volume "kube-api-access-*": failed to fetch token: serviceaccounts "lfx-v2-auth-service" not found`

## Fix

By always creating the SA and always referencing it, Helm manages `serviceAccountName` as a stable, explicit field — it will never be absent from a patch, so the three-way merge issue disappears. The SA in `mock`/`auth0` mode has no Role or RoleBinding, so it carries no cluster permissions beyond the Kubernetes default.

## Ticket

[LFXV2 / LFX One](https://linuxfoundation.atlassian.net/browse/LFXV2)

## Test Plan

- [ ] Deploy with `USER_REPOSITORY_TYPE: mock` — pod starts successfully
- [ ] Switch from `authelia` → `mock` via helm upgrade — no FailedMount errors during rollout
- [ ] Switch from `mock` → `authelia` via helm upgrade — Role and RoleBinding appear, pod still works
- [ ] Verify in `mock` mode: SA exists, no Role/RoleBinding in cluster

🤖 Generated with [Claude Code](https://claude.ai/code)