### PR TITLE
feat(LFXV2-1919): add domain-scoped alias ownership via system-managed Auth0 identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ setup: ## Setup development environment
 .PHONY: lint
 lint: ## Run golangci-lint (local Go linting)
 	@echo "Running golangci-lint..."
-	@which golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	@which golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 	@golangci-lint run ./... && echo "==> Lint OK"
 
 # Format code

--- a/cmd/server/service/message_handler.go
+++ b/cmd/server/service/message_handler.go
@@ -42,6 +42,8 @@ func (mhs *MessageHandlerService) HandleMessage(ctx context.Context, msg port.Tr
 		constants.UserIdentityLinkSubject:   mhs.messageHandler.LinkIdentity,
 		constants.UserIdentityUnlinkSubject: mhs.messageHandler.UnlinkIdentity,
 		constants.UserIdentityListSubject:   mhs.messageHandler.ListIdentities,
+		// alias management
+		constants.UserAddLcomAliasSubject: mhs.messageHandler.AddLcomAlias,
 		// password management operations
 		constants.PasswordUpdateSubject:    mhs.messageHandler.ChangePassword,
 		constants.PasswordResetLinkSubject: mhs.messageHandler.SendResetPasswordLink,

--- a/cmd/server/service/message_handler.go
+++ b/cmd/server/service/message_handler.go
@@ -43,7 +43,7 @@ func (mhs *MessageHandlerService) HandleMessage(ctx context.Context, msg port.Tr
 		constants.UserIdentityUnlinkSubject: mhs.messageHandler.UnlinkIdentity,
 		constants.UserIdentityListSubject:   mhs.messageHandler.ListIdentities,
 		// alias management
-		constants.UserAddLcomAliasSubject: mhs.messageHandler.AddLcomAlias,
+		constants.UserAddAliasSubject: mhs.messageHandler.AddAlias,
 		// password management operations
 		constants.PasswordUpdateSubject:    mhs.messageHandler.ChangePassword,
 		constants.PasswordResetLinkSubject: mhs.messageHandler.SendResetPasswordLink,

--- a/cmd/server/service/providers.go
+++ b/cmd/server/service/providers.go
@@ -194,10 +194,18 @@ func QueueSubscriptions(ctx context.Context) error {
 		service.WithIdentityUnlinkerForMessageHandler(userReaderWriter),
 		service.WithPasswordHandlerForMessageHandler(userReaderWriter),
 		service.WithEventPublisherForMessageHandler(natsClient),
-		service.WithAliasManagerForMessageHandler(userReaderWriter),
 	}
 
-	if os.Getenv(constants.UserRepositoryTypeEnvKey) == constants.UserRepositoryTypeAuth0 {
+	// Only wire the alias manager for backends that meaningfully support
+	// system-managed @linux.com aliases. Authelia returns a backend-specific
+	// validation error; leaving it nil lets AddLcomAlias surface the stable
+	// "alias service unavailable" guard instead.
+	userRepoType := os.Getenv(constants.UserRepositoryTypeEnvKey)
+	if userRepoType == constants.UserRepositoryTypeAuth0 || userRepoType == constants.UserRepositoryTypeMock || userRepoType == "" {
+		opts = append(opts, service.WithAliasManagerForMessageHandler(userReaderWriter))
+	}
+
+	if userRepoType == constants.UserRepositoryTypeAuth0 {
 		auth0Domain := os.Getenv(constants.Auth0DomainEnvKey)
 		if auth0Domain == "" {
 			auth0Domain = fmt.Sprintf("%s.auth0.com", os.Getenv(constants.Auth0TenantEnvKey))

--- a/cmd/server/service/providers.go
+++ b/cmd/server/service/providers.go
@@ -197,8 +197,8 @@ func QueueSubscriptions(ctx context.Context) error {
 	}
 
 	// Only wire the alias manager for backends that meaningfully support
-	// system-managed @linux.com aliases. Authelia returns a backend-specific
-	// validation error; leaving it nil lets AddLcomAlias surface the stable
+	// system-managed aliases. Authelia returns a backend-specific validation
+	// error; leaving it nil lets AddAlias surface the stable
 	// "alias service unavailable" guard instead.
 	userRepoType := os.Getenv(constants.UserRepositoryTypeEnvKey)
 	if userRepoType == constants.UserRepositoryTypeAuth0 || userRepoType == constants.UserRepositoryTypeMock || userRepoType == "" {
@@ -243,7 +243,7 @@ func QueueSubscriptions(ctx context.Context) error {
 		constants.UserIdentityLinkSubject:             messageHandlerService.HandleMessage,
 		constants.UserIdentityUnlinkSubject:           messageHandlerService.HandleMessage,
 		constants.UserIdentityListSubject:             messageHandlerService.HandleMessage,
-		constants.UserAddLcomAliasSubject:             messageHandlerService.HandleMessage,
+		constants.UserAddAliasSubject:                 messageHandlerService.HandleMessage,
 		constants.PasswordUpdateSubject:               messageHandlerService.HandleMessage,
 		constants.PasswordResetLinkSubject:            messageHandlerService.HandleMessage,
 		constants.ImpersonationTokenExchangeSubject:   messageHandlerService.HandleMessage,

--- a/cmd/server/service/providers.go
+++ b/cmd/server/service/providers.go
@@ -194,6 +194,7 @@ func QueueSubscriptions(ctx context.Context) error {
 		service.WithIdentityUnlinkerForMessageHandler(userReaderWriter),
 		service.WithPasswordHandlerForMessageHandler(userReaderWriter),
 		service.WithEventPublisherForMessageHandler(natsClient),
+		service.WithAliasManagerForMessageHandler(userReaderWriter),
 	}
 
 	if os.Getenv(constants.UserRepositoryTypeEnvKey) == constants.UserRepositoryTypeAuth0 {
@@ -234,6 +235,7 @@ func QueueSubscriptions(ctx context.Context) error {
 		constants.UserIdentityLinkSubject:             messageHandlerService.HandleMessage,
 		constants.UserIdentityUnlinkSubject:           messageHandlerService.HandleMessage,
 		constants.UserIdentityListSubject:             messageHandlerService.HandleMessage,
+		constants.UserAddLcomAliasSubject:             messageHandlerService.HandleMessage,
 		constants.PasswordUpdateSubject:               messageHandlerService.HandleMessage,
 		constants.PasswordResetLinkSubject:            messageHandlerService.HandleMessage,
 		constants.ImpersonationTokenExchangeSubject:   messageHandlerService.HandleMessage,

--- a/cmd/server/service/providers.go
+++ b/cmd/server/service/providers.go
@@ -199,7 +199,7 @@ func QueueSubscriptions(ctx context.Context) error {
 	// Only wire the alias manager for backends that meaningfully support
 	// system-managed aliases. Authelia returns a backend-specific validation
 	// error; leaving it nil lets AddAlias surface the stable
-	// "alias service unavailable" guard instead.
+	// "alias_service_unavailable" guard instead.
 	userRepoType := os.Getenv(constants.UserRepositoryTypeEnvKey)
 	if userRepoType == constants.UserRepositoryTypeAuth0 || userRepoType == constants.UserRepositoryTypeMock || userRepoType == "" {
 		opts = append(opts, service.WithAliasManagerForMessageHandler(userReaderWriter))

--- a/docs/alias.md
+++ b/docs/alias.md
@@ -60,10 +60,10 @@ The returned `email` is the canonical, lowercased form of the claimed alias.
 | `alias_reserved` | The alias matches a reserved name (built-in list or `AUTH0_ALIAS_RESERVED_EXTRA`) |
 | `alias_not_available` | The full `<alias>@<domain>` address is already linked to another user (also returned on a race during claim) |
 | `already_claimed` | The caller already has an alias on this domain as primary, linked identity, or alternate email |
-| `alias service unavailable` | The current backend does not support alias claims (e.g. Authelia) |
-| `auth service unavailable` | The user reader is not wired |
+| `alias_service_unavailable` | The current backend does not support alias claims (e.g. Authelia) |
+| `auth_service_unavailable` | The user reader is not wired |
 | `auth_token is required` | Missing `user.auth_token` in the request |
-| `failed to unmarshal request` | Request JSON is malformed |
+| `failed_to_unmarshal_request` | Request JSON is malformed |
 
 Operational errors from the backend (Auth0 outage, M2M token failure, etc.) propagate their raw message rather than mapping to one of the codes above.
 

--- a/docs/alias.md
+++ b/docs/alias.md
@@ -1,0 +1,174 @@
+# Alias Operations
+
+This document describes the NATS subject for claiming a system-managed alias (e.g. `@linux.com`) as a verified secondary email on a user account.
+
+An alias is a system-managed Auth0 identity linked onto the caller's primary user. Once claimed it is **immutable** — the unlink path refuses to remove it. Each user may hold at most one alias per allowed domain.
+
+The target domain is supplied per-request and must be present in the server-side `ALLOWED_ALIAS_DOMAINS` allow-list. This lets production run with `linux.com` while dev/staging environments use their own test domains, without any caller able to claim aliases on arbitrary domains.
+
+---
+
+## Add Alias
+
+**Subject:** `lfx.auth-service.add_alias`
+**Pattern:** Request/Reply
+
+### Request Payload
+
+```json
+{
+  "user": {
+    "auth_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+  },
+  "alias": "jane.doe",
+  "domain": "linux.com"
+}
+```
+
+### Request Fields
+
+- `user.auth_token` (string, required): A valid JWT identifying the caller. Must carry the `update:current_user_identities` scope.
+- `alias` (string, required): The local part of the desired address. Do not include `@` or the domain suffix.
+- `domain` (string, required): The domain to claim under. Must be present (case-insensitive) in the server's `ALLOWED_ALIAS_DOMAINS` env list, otherwise the request is rejected with `domain_not_allowed`.
+
+### Reply
+
+**Success Reply:**
+```json
+{
+  "success": true,
+  "email": "jane.doe@linux.com"
+}
+```
+
+The returned `email` is the canonical, lowercased form of the claimed alias.
+
+**Error Reply:**
+```json
+{
+  "success": false,
+  "error": "alias_invalid"
+}
+```
+
+### Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `domain_not_allowed` | The requested `domain` is missing, empty, or not present in `ALLOWED_ALIAS_DOMAINS` |
+| `alias_invalid` | The alias is empty, too long (>64 chars), contains banned characters, or fails RFC 5322 canonicalisation |
+| `alias_reserved` | The alias matches a reserved name (built-in list or `AUTH0_ALIAS_RESERVED_EXTRA`) |
+| `alias_not_available` | The full `<alias>@<domain>` address is already linked to another user (also returned on a race during claim) |
+| `already_claimed` | The caller already has an alias on this domain as primary, linked identity, or alternate email |
+| `alias service unavailable` | The current backend does not support alias claims (e.g. Authelia) |
+| `auth service unavailable` | The user reader is not wired |
+| `auth_token is required` | Missing `user.auth_token` in the request |
+| `failed to unmarshal request` | Request JSON is malformed |
+
+Operational errors from the backend (Auth0 outage, M2M token failure, etc.) propagate their raw message rather than mapping to one of the codes above.
+
+### Validation Rules
+
+**Domain (`request.domain`):**
+- Lowercased and trimmed on read
+- Must be non-empty and present in `ALLOWED_ALIAS_DOMAINS` (case-insensitive)
+- Empty/unset env → feature is disabled, every claim fails with `domain_not_allowed`
+
+**Alias local part (`request.alias`):**
+
+The alias is normalised by trimming whitespace and lower-casing, then validated as follows:
+
+- **Length**: 1–64 characters after trimming
+- **Banned characters**: `"`, `/`, `*`, `$`, `^`, `:`, `@`, space, `;`, and other characters that would break RFC 5322 local parts or allow quoted-form bypass
+- **RFC 5322 round-trip**: the input is reconstructed as `<norm>@<domain>` and parsed with `net/mail.ParseAddress`; the canonical form must equal the reconstructed string. This guards against the quoted-local-part bypass (e.g. `"admin"`)
+- **Reserved names** (case-insensitive, applied on every domain): `postmaster`, `abuse`, `hostmaster`, `admin`, `administrator`, `noreply`, `no-reply`, `root`, `mailer-daemon`, `linux`, `linuxfoundation`, `lf`, `security`, `support`, `info`, `webmaster`, `ops`, `devops`, `itx-system`
+- **Extra reserved names**: any entry in the comma-separated `AUTH0_ALIAS_RESERVED_EXTRA` environment variable is added to the reserved list (case-insensitive)
+
+### System-Managed Semantics
+
+When a claim succeeds, the Auth0 adapter:
+
+1. Creates a passwordless **stub user** on the `email` connection with `email_verified: true` and `app_metadata.system_managed: true` via `POST /api/v2/users`.
+2. Links the stub onto the caller's primary user via `POST /api/v2/users/{primary}/identities`.
+3. If the link step fails, performs a best-effort rollback by deleting the orphaned stub.
+
+The `system_managed` flag lives on the **stub user record**, which continues to exist after the link (Auth0 transplants the identity entry into the primary's `identities` array but the stub record stays around at its original `user_id`).
+
+### Why `provider: "email"`?
+
+The linked identity reports `provider: "email"` because Auth0's `provider` field maps to a fixed set of connection **strategies** (`auth0`, `email`, `sms`, `google-oauth2`, etc.) — it is not a free-form label this service controls. The passwordless `email` strategy is the right fit for system-managed aliases (no password, pre-verified, linkable as a secondary).
+
+To distinguish a system-managed alias from a regular email identity, callers should either:
+
+- Check the email suffix against `ALLOWED_ALIAS_DOMAINS`, **or**
+- Fetch the stub user record and check `app_metadata.system_managed == true`.
+
+### Unlink Guard
+
+A subsequent `lfx.auth-service.user_identity.unlink` call targeting an `email`-connection identity triggers the immutability guard in the Auth0 adapter:
+
+1. Non-`email` providers (oauth2/social) short-circuit and proceed normally.
+2. For `email` providers, the adapter fetches the stub user record via M2M (`GET /api/v2/users/email|<id>`).
+3. **Fail-closed**: any non-404 fetch error returns an `Unexpected` error so a flaky Auth0 cannot silently allow the unlink.
+4. If `app_metadata.system_managed == true`, the adapter returns `errors.NewForbidden("system_managed_identity")`.
+
+The mock adapter mirrors this guard: any `email`-connection entry in `user.Identities` is by construction system-managed (only `AddSystemManagedEmail` writes there), so the mock refuses the unlink with the same error.
+
+### Surfacing in `user_emails.read`
+
+Once linked, the alias appears in the `alternate_emails` array returned by `lfx.auth-service.user_emails.read`, alongside any other email-connection identities on the account.
+
+### Example using NATS CLI
+
+```bash
+# Production (ALLOWED_ALIAS_DOMAINS=linux.com)
+nats request lfx.auth-service.add_alias \
+  '{"user":{"auth_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."},"alias":"jane.doe","domain":"linux.com"}'
+
+# Dev (ALLOWED_ALIAS_DOMAINS=dev.lfx.example)
+nats request lfx.auth-service.add_alias \
+  '{"user":{"auth_token":"..."},"alias":"jane.doe","domain":"dev.lfx.example"}'
+```
+
+### Provider Support
+
+| Provider | Support |
+|----------|---------|
+| Auth0    | Full — creates a system-managed stub on the `email` connection, links it, and rolls back on link failure |
+| Mock     | Simulated — appends an `email`-connection identity and enforces the same unlink guard |
+| Authelia | Not supported — returns `alias service unavailable` |
+
+### Environment Configuration
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `ALLOWED_ALIAS_DOMAINS` | Comma-separated list of domains permitted as alias suffix. Case-insensitive. Empty/unset disables the feature. | _(unset → disabled)_ |
+| `AUTH0_ALIAS_RESERVED_EXTRA` | Comma-separated list of additional reserved local parts on top of the built-in list. Case-insensitive. | _(unset)_ |
+
+### Required Auth0 Configuration
+
+The `lfx_v2_auth_service` M2M application must hold the following scopes on the Management API:
+
+- `read:users` — search for existing claims, fetch stub for the unlink guard
+- `create:users` — create the stub
+- `update:users` — link the stub identity onto the primary user
+- `delete:users` — rollback an orphaned stub on link failure
+
+These scopes are provisioned via the companion `auth0-terraform` repository — see `grants_auth0v2.tf` for the `lfx_v2_auth_service` grant.
+
+### Important Notes
+
+- Requires the `update:current_user_identities` scope in the JWT.
+- The domain is caller-supplied and validated against the server-side allow-list — there is no implicit default.
+- Each user may hold at most one alias **per allowed domain**. With multiple domains in the allow-list, a user could in principle claim one alias on each (e.g. `jane@linux.com` and `jane@dev.lfx.example`).
+- A successful claim is immutable from the user's perspective: only an administrator with direct Auth0 access can flip `app_metadata.system_managed` and remove the alias.
+- For detailed Auth0-specific behavior and limitations, see: [`../internal/infrastructure/auth0/README.md`](../internal/infrastructure/auth0/README.md)
+
+---
+
+## Related Subjects
+
+- **Identity Linking** (general link/unlink/list flow): [`identity_linking.md`](identity_linking.md)
+- **User Emails** (where the alias surfaces): [`user_emails.md`](user_emails.md)
+- **Email Lookups**: [`email_lookups.md`](email_lookups.md)
+- **User Metadata**: [`user_metadata.md`](user_metadata.md)

--- a/docs/identity_linking.md
+++ b/docs/identity_linking.md
@@ -236,3 +236,13 @@ The Mock implementation follows the same sub-prefix dispatch and storage targets
 ## Email Verification Flow
 
 When linking an email identity, `lfx.auth-service.user_identity.link` is used as the final step after completing the OTP verification. For the complete flow see [Email Verification Documentation](email_verification.md#complete-email-verification-and-linking-flow).
+
+---
+
+## Alias Flow (system-managed)
+
+Claiming a system-managed alias (e.g. `@linux.com`) does **not** go through `lfx.auth-service.user_identity.link`. It uses a dedicated subject (`lfx.auth-service.add_alias`) that creates a passwordless Auth0 stub user with `app_metadata.system_managed=true` and links it via the Management API — no user-facing OTP, no client-side identity token. The resulting identity is **immutable**: the unlink guard refuses to remove it.
+
+The target domain is caller-supplied and validated against the server-side `ALLOWED_ALIAS_DOMAINS` allow-list.
+
+See [alias.md](alias.md) for the full specification, validation rules, error codes, and required Auth0 scopes.

--- a/internal/domain/model/alias.go
+++ b/internal/domain/model/alias.go
@@ -1,0 +1,69 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package model
+
+import (
+	"net/mail"
+	"strings"
+)
+
+// lcomReservedNames is the canonical set of local parts that may not be claimed
+// as @linux.com aliases. Extended at runtime via the
+// AUTH0_LCOM_ALIAS_RESERVED_EXTRA environment variable.
+var lcomReservedNames = map[string]struct{}{
+	"postmaster":      {},
+	"abuse":           {},
+	"hostmaster":      {},
+	"admin":           {},
+	"administrator":   {},
+	"noreply":         {},
+	"no-reply":        {},
+	"root":            {},
+	"mailer-daemon":   {},
+	"linux":           {},
+	"linuxfoundation": {},
+	"lf":              {},
+	"security":        {},
+	"support":         {},
+	"info":            {},
+	"webmaster":       {},
+	"ops":             {},
+	"devops":          {},
+	"itx-system":      {},
+}
+
+// lcomBannedChars are characters disallowed in an @linux.com alias local part,
+// ported from itx-service-forwards/forwards.go:309-327.
+const lcomBannedChars = `/*$^:()<>[];@\, `
+
+// ValidateLcomAlias normalises alias (lowercases + trims) and returns
+// ("", "alias_invalid") or ("", "alias_reserved") on failure, or
+// (normalised, "") on success.
+func ValidateLcomAlias(alias string, extraReserved []string) (string, string) {
+	alias = strings.ToLower(strings.TrimSpace(alias))
+
+	if len(alias) == 0 || len(alias) > 64 {
+		return "", "alias_invalid"
+	}
+
+	if strings.ContainsAny(alias, lcomBannedChars) {
+		return "", "alias_invalid"
+	}
+
+	// RFC 5322 round-trip: ensure the full address parses cleanly.
+	if _, err := mail.ParseAddress(alias + "@linux.com"); err != nil {
+		return "", "alias_invalid"
+	}
+
+	if _, reserved := lcomReservedNames[alias]; reserved {
+		return "", "alias_reserved"
+	}
+	for _, extra := range extraReserved {
+		if strings.EqualFold(alias, strings.TrimSpace(extra)) {
+			return "", "alias_reserved"
+		}
+	}
+
+	return alias, ""
+}

--- a/internal/domain/model/alias.go
+++ b/internal/domain/model/alias.go
@@ -34,8 +34,11 @@ var lcomReservedNames = map[string]struct{}{
 }
 
 // lcomBannedChars are characters disallowed in an @linux.com alias local part,
-// ported from itx-service-forwards/forwards.go:309-327.
-const lcomBannedChars = `/*$^:()<>[];@\, `
+// ported from itx-service-forwards/forwards.go:309-327. The double-quote is
+// included to prevent reserved-name bypass via RFC 5322 quoted local-parts
+// (e.g. `"admin"@linux.com` would otherwise parse and canonicalize to
+// `admin@linux.com`, slipping past the reserved-name check on the raw alias).
+const lcomBannedChars = `/*$^:()<>[];@\, "`
 
 // ValidateLcomAlias normalises alias (lowercases + trims) and returns
 // ("", "alias_invalid") or ("", "alias_reserved") on failure, or
@@ -51,8 +54,11 @@ func ValidateLcomAlias(alias string, extraReserved []string) (string, string) {
 		return "", "alias_invalid"
 	}
 
-	// RFC 5322 round-trip: ensure the full address parses cleanly.
-	if _, err := mail.ParseAddress(alias + "@linux.com"); err != nil {
+	// Ensure the address parses and that net/mail's canonical form matches the
+	// input verbatim. This catches any other surface (escapes, encoded forms)
+	// that could let a normalised value differ from `alias`.
+	parsed, err := mail.ParseAddress(alias + "@linux.com")
+	if err != nil || !strings.EqualFold(parsed.Address, alias+"@linux.com") {
 		return "", "alias_invalid"
 	}
 

--- a/internal/domain/model/alias.go
+++ b/internal/domain/model/alias.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 )
 
-// lcomReservedNames is the canonical set of local parts that may not be claimed
-// as @linux.com aliases. Extended at runtime via the
-// AUTH0_LCOM_ALIAS_RESERVED_EXTRA environment variable.
-var lcomReservedNames = map[string]struct{}{
+// aliasReservedNames is the canonical set of local parts that may not be claimed
+// as system-managed aliases on any allowed domain. Extended at runtime via the
+// AUTH0_ALIAS_RESERVED_EXTRA environment variable. These names are reserved
+// regardless of the requested domain because they are universally sensitive
+// (RFC 2142 mailbox names, LF branding terms, etc.).
+var aliasReservedNames = map[string]struct{}{
 	"postmaster":      {},
 	"abuse":           {},
 	"hostmaster":      {},
@@ -33,36 +35,40 @@ var lcomReservedNames = map[string]struct{}{
 	"itx-system":      {},
 }
 
-// lcomBannedChars are characters disallowed in an @linux.com alias local part,
-// ported from itx-service-forwards/forwards.go:309-327. The double-quote is
-// included to prevent reserved-name bypass via RFC 5322 quoted local-parts
-// (e.g. `"admin"@linux.com` would otherwise parse and canonicalize to
-// `admin@linux.com`, slipping past the reserved-name check on the raw alias).
-const lcomBannedChars = `/*$^:()<>[];@\, "`
+// aliasBannedChars are characters disallowed in an alias local part. The
+// double-quote is included to prevent reserved-name bypass via RFC 5322 quoted
+// local-parts (e.g. `"admin"@<domain>` would otherwise parse and canonicalize
+// to `admin@<domain>`, slipping past the reserved-name check on the raw alias).
+const aliasBannedChars = `/*$^:()<>[];@\, "`
 
-// ValidateLcomAlias normalises alias (lowercases + trims) and returns
+// ValidateAlias normalises alias (lowercases + trims) and validates it as a
+// local part that can be safely appended to "@<domain>". Returns
 // ("", "alias_invalid") or ("", "alias_reserved") on failure, or
-// (normalised, "") on success.
-func ValidateLcomAlias(alias string, extraReserved []string) (string, string) {
+// (normalised, "") on success. The domain is used only for the RFC 5322
+// round-trip canonicalisation check — callers are responsible for verifying
+// the domain itself is allowed before calling this function.
+func ValidateAlias(alias, domain string, extraReserved []string) (string, string) {
 	alias = strings.ToLower(strings.TrimSpace(alias))
+	domain = strings.ToLower(strings.TrimSpace(domain))
 
 	if len(alias) == 0 || len(alias) > 64 {
 		return "", "alias_invalid"
 	}
 
-	if strings.ContainsAny(alias, lcomBannedChars) {
+	if strings.ContainsAny(alias, aliasBannedChars) {
 		return "", "alias_invalid"
 	}
 
 	// Ensure the address parses and that net/mail's canonical form matches the
 	// input verbatim. This catches any other surface (escapes, encoded forms)
 	// that could let a normalised value differ from `alias`.
-	parsed, err := mail.ParseAddress(alias + "@linux.com")
-	if err != nil || !strings.EqualFold(parsed.Address, alias+"@linux.com") {
+	full := alias + "@" + domain
+	parsed, err := mail.ParseAddress(full)
+	if err != nil || !strings.EqualFold(parsed.Address, full) {
 		return "", "alias_invalid"
 	}
 
-	if _, reserved := lcomReservedNames[alias]; reserved {
+	if _, reserved := aliasReservedNames[alias]; reserved {
 		return "", "alias_reserved"
 	}
 	for _, extra := range extraReserved {

--- a/internal/domain/model/alias_test.go
+++ b/internal/domain/model/alias_test.go
@@ -85,6 +85,16 @@ func TestValidateLcomAlias(t *testing.T) {
 
 		// Invalid — banned chars
 		{
+			name:        "double-quoted alias rejected (RFC 5322 bypass guard)",
+			alias:       `"jdoe"`,
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "double-quoted reserved alias rejected",
+			alias:       `"admin"`,
+			wantErrCode: "alias_invalid",
+		},
+		{
 			name:        "slash",
 			alias:       "jane/doe",
 			wantErrCode: "alias_invalid",

--- a/internal/domain/model/alias_test.go
+++ b/internal/domain/model/alias_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 )
 
-func TestValidateLcomAlias(t *testing.T) {
+func TestValidateAlias(t *testing.T) {
+	const testDomain = "linux.com"
+
 	tests := []struct {
 		name          string
 		alias         string
@@ -267,18 +269,18 @@ func TestValidateLcomAlias(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			norm, errCode := ValidateLcomAlias(tt.alias, tt.extraReserved)
+			norm, errCode := ValidateAlias(tt.alias, testDomain, tt.extraReserved)
 
 			if errCode != tt.wantErrCode {
-				t.Errorf("ValidateLcomAlias(%q) errCode = %q, want %q", tt.alias, errCode, tt.wantErrCode)
+				t.Errorf("ValidateAlias(%q) errCode = %q, want %q", tt.alias, errCode, tt.wantErrCode)
 			}
 
 			if tt.wantErrCode == "" && norm != tt.wantNorm {
-				t.Errorf("ValidateLcomAlias(%q) norm = %q, want %q", tt.alias, norm, tt.wantNorm)
+				t.Errorf("ValidateAlias(%q) norm = %q, want %q", tt.alias, norm, tt.wantNorm)
 			}
 
 			if tt.wantErrCode != "" && norm != "" {
-				t.Errorf("ValidateLcomAlias(%q) expected empty norm on error, got %q", tt.alias, norm)
+				t.Errorf("ValidateAlias(%q) expected empty norm on error, got %q", tt.alias, norm)
 			}
 		})
 	}

--- a/internal/domain/model/alias_test.go
+++ b/internal/domain/model/alias_test.go
@@ -137,108 +137,6 @@ func TestValidateAlias(t *testing.T) {
 			wantErrCode: "alias_invalid",
 		},
 
-		// Reserved names — all 19
-		{
-			name:        "postmaster reserved",
-			alias:       "postmaster",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "abuse reserved",
-			alias:       "abuse",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "hostmaster reserved",
-			alias:       "hostmaster",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "admin reserved",
-			alias:       "admin",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "administrator reserved",
-			alias:       "administrator",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "noreply reserved",
-			alias:       "noreply",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "no-reply reserved",
-			alias:       "no-reply",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "root reserved",
-			alias:       "root",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "mailer-daemon reserved",
-			alias:       "mailer-daemon",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "linux reserved",
-			alias:       "linux",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "linuxfoundation reserved",
-			alias:       "linuxfoundation",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "lf reserved",
-			alias:       "lf",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "security reserved",
-			alias:       "security",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "support reserved",
-			alias:       "support",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "info reserved",
-			alias:       "info",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "webmaster reserved",
-			alias:       "webmaster",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "ops reserved",
-			alias:       "ops",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "devops reserved",
-			alias:       "devops",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "itx-system reserved",
-			alias:       "itx-system",
-			wantErrCode: "alias_reserved",
-		},
-		{
-			name:        "reserved name case-insensitive",
-			alias:       "ADMIN",
-			wantErrCode: "alias_reserved",
-		},
-
 		// Extra reserved
 		{
 			name:          "extra reserved name blocked",
@@ -281,6 +179,24 @@ func TestValidateAlias(t *testing.T) {
 
 			if tt.wantErrCode != "" && norm != "" {
 				t.Errorf("ValidateAlias(%q) expected empty norm on error, got %q", tt.alias, norm)
+			}
+		})
+	}
+
+	// Loop over the canonical reserved set so any future additions to
+	// aliasReservedNames are automatically covered without updating this file.
+	for name := range aliasReservedNames {
+		name := name
+		t.Run(name+" reserved (builtin)", func(t *testing.T) {
+			_, code := ValidateAlias(name, testDomain, nil)
+			if code != "alias_reserved" {
+				t.Errorf("expected alias_reserved for built-in reserved name %q, got %q", name, code)
+			}
+		})
+		t.Run(name+" reserved uppercase (builtin)", func(t *testing.T) {
+			_, code := ValidateAlias(strings.ToUpper(name), testDomain, nil)
+			if code != "alias_reserved" {
+				t.Errorf("expected alias_reserved for upper-cased built-in reserved name %q, got %q", strings.ToUpper(name), code)
 			}
 		})
 	}

--- a/internal/domain/model/alias_test.go
+++ b/internal/domain/model/alias_test.go
@@ -1,0 +1,275 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateLcomAlias(t *testing.T) {
+	tests := []struct {
+		name          string
+		alias         string
+		extraReserved []string
+		wantNorm      string
+		wantErrCode   string
+	}{
+		// Happy paths
+		{
+			name:        "simple valid alias",
+			alias:       "jdoe",
+			wantNorm:    "jdoe",
+			wantErrCode: "",
+		},
+		{
+			name:        "alias with hyphen",
+			alias:       "jane-doe",
+			wantNorm:    "jane-doe",
+			wantErrCode: "",
+		},
+		{
+			name:        "alias with dot",
+			alias:       "jane.doe",
+			wantNorm:    "jane.doe",
+			wantErrCode: "",
+		},
+		{
+			name:        "alias with plus",
+			alias:       "jane+doe",
+			wantNorm:    "jane+doe",
+			wantErrCode: "",
+		},
+		{
+			name:        "uppercase is normalised to lowercase",
+			alias:       "JaneDoe",
+			wantNorm:    "janedoe",
+			wantErrCode: "",
+		},
+		{
+			name:        "leading/trailing whitespace trimmed",
+			alias:       "  jdoe  ",
+			wantNorm:    "jdoe",
+			wantErrCode: "",
+		},
+		{
+			name:        "single character",
+			alias:       "x",
+			wantNorm:    "x",
+			wantErrCode: "",
+		},
+		{
+			name:        "exactly 64 characters",
+			alias:       strings.Repeat("a", 64),
+			wantNorm:    strings.Repeat("a", 64),
+			wantErrCode: "",
+		},
+
+		// Invalid — length
+		{
+			name:        "empty alias",
+			alias:       "",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "whitespace only",
+			alias:       "   ",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "65 characters — too long",
+			alias:       strings.Repeat("b", 65),
+			wantErrCode: "alias_invalid",
+		},
+
+		// Invalid — banned chars
+		{
+			name:        "slash",
+			alias:       "jane/doe",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "asterisk",
+			alias:       "jane*doe",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "dollar sign",
+			alias:       "jane$doe",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "caret",
+			alias:       "jane^doe",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "colon",
+			alias:       "jane:doe",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "at sign",
+			alias:       "jane@doe",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "space in middle",
+			alias:       "jane doe",
+			wantErrCode: "alias_invalid",
+		},
+		{
+			name:        "semicolon",
+			alias:       "jane;doe",
+			wantErrCode: "alias_invalid",
+		},
+
+		// Reserved names — all 19
+		{
+			name:        "postmaster reserved",
+			alias:       "postmaster",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "abuse reserved",
+			alias:       "abuse",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "hostmaster reserved",
+			alias:       "hostmaster",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "admin reserved",
+			alias:       "admin",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "administrator reserved",
+			alias:       "administrator",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "noreply reserved",
+			alias:       "noreply",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "no-reply reserved",
+			alias:       "no-reply",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "root reserved",
+			alias:       "root",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "mailer-daemon reserved",
+			alias:       "mailer-daemon",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "linux reserved",
+			alias:       "linux",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "linuxfoundation reserved",
+			alias:       "linuxfoundation",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "lf reserved",
+			alias:       "lf",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "security reserved",
+			alias:       "security",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "support reserved",
+			alias:       "support",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "info reserved",
+			alias:       "info",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "webmaster reserved",
+			alias:       "webmaster",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "ops reserved",
+			alias:       "ops",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "devops reserved",
+			alias:       "devops",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "itx-system reserved",
+			alias:       "itx-system",
+			wantErrCode: "alias_reserved",
+		},
+		{
+			name:        "reserved name case-insensitive",
+			alias:       "ADMIN",
+			wantErrCode: "alias_reserved",
+		},
+
+		// Extra reserved
+		{
+			name:          "extra reserved name blocked",
+			alias:         "cncf",
+			extraReserved: []string{"cncf"},
+			wantErrCode:   "alias_reserved",
+		},
+		{
+			name:          "extra reserved case-insensitive",
+			alias:         "CNCF",
+			extraReserved: []string{"cncf"},
+			wantErrCode:   "alias_reserved",
+		},
+		{
+			name:          "extra reserved with whitespace",
+			alias:         "cncf",
+			extraReserved: []string{"  cncf  "},
+			wantErrCode:   "alias_reserved",
+		},
+		{
+			name:          "alias not in extra reserved",
+			alias:         "jdoe",
+			extraReserved: []string{"cncf"},
+			wantNorm:      "jdoe",
+			wantErrCode:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			norm, errCode := ValidateLcomAlias(tt.alias, tt.extraReserved)
+
+			if errCode != tt.wantErrCode {
+				t.Errorf("ValidateLcomAlias(%q) errCode = %q, want %q", tt.alias, errCode, tt.wantErrCode)
+			}
+
+			if tt.wantErrCode == "" && norm != tt.wantNorm {
+				t.Errorf("ValidateLcomAlias(%q) norm = %q, want %q", tt.alias, norm, tt.wantNorm)
+			}
+
+			if tt.wantErrCode != "" && norm != "" {
+				t.Errorf("ValidateLcomAlias(%q) expected empty norm on error, got %q", tt.alias, norm)
+			}
+		})
+	}
+}

--- a/internal/domain/port/message_handler.go
+++ b/internal/domain/port/message_handler.go
@@ -23,7 +23,7 @@ type UserHandler interface {
 
 // AliasMessageHandler defines the behavior of the alias management domain handlers.
 type AliasMessageHandler interface {
-	AddLcomAlias(ctx context.Context, msg TransportMessenger) ([]byte, error)
+	AddAlias(ctx context.Context, msg TransportMessenger) ([]byte, error)
 }
 
 // UserReadHandler defines the behavior of the user read/lookup domain handlers

--- a/internal/domain/port/message_handler.go
+++ b/internal/domain/port/message_handler.go
@@ -18,6 +18,12 @@ type UserHandler interface {
 	UserLookupHandler
 	UserLinkHandler
 	PasswordManagementHandler
+	AliasMessageHandler
+}
+
+// AliasMessageHandler defines the behavior of the alias management domain handlers.
+type AliasMessageHandler interface {
+	AddLcomAlias(ctx context.Context, msg TransportMessenger) ([]byte, error)
 }
 
 // UserReadHandler defines the behavior of the user read/lookup domain handlers

--- a/internal/domain/port/user.go
+++ b/internal/domain/port/user.go
@@ -56,7 +56,7 @@ type PasswordHandler interface {
 // (M2M) and does not require a user-facing identity token.
 type AliasManager interface {
 	// AddSystemManagedEmail creates a stub passwordless user for email, links it
-	// to primaryUserID, and marks it system_managed so it cannot be user-unlinkd.
+	// to primaryUserID, and marks it system_managed so it cannot be user-unlinked.
 	// Returns the stub Auth0 user_id for audit purposes.
 	AddSystemManagedEmail(ctx context.Context, primaryUserID, email string) (string, error)
 }

--- a/internal/domain/port/user.go
+++ b/internal/domain/port/user.go
@@ -16,6 +16,7 @@ type UserReaderWriter interface {
 	EmailHandler
 	IdentityLinker
 	PasswordHandler
+	AliasManager
 }
 
 // UserReader defines the behavior of the user reader
@@ -48,4 +49,14 @@ type EmailHandler interface {
 type PasswordHandler interface {
 	ChangePassword(ctx context.Context, user *model.User, currentPassword, newPassword string) error
 	SendResetPasswordLink(ctx context.Context, user *model.User) error
+}
+
+// AliasManager defines the behavior for managing system-managed email aliases.
+// It is kept separate from IdentityLinker because the link is server-initiated
+// (M2M) and does not require a user-facing identity token.
+type AliasManager interface {
+	// AddSystemManagedEmail creates a stub passwordless user for email, links it
+	// to primaryUserID, and marks it system_managed so it cannot be user-unlinkd.
+	// Returns the stub Auth0 user_id for audit purposes.
+	AddSystemManagedEmail(ctx context.Context, primaryUserID, email string) (string, error)
 }

--- a/internal/infrastructure/auth0/models.go
+++ b/internal/infrastructure/auth0/models.go
@@ -30,8 +30,8 @@ type Auth0User struct {
 // Only fields relevant to this service are modeled; unknown keys are ignored.
 type Auth0AppMetadata struct {
 	// SystemManaged marks an identity that was created by this service on behalf
-	// of the user (e.g. an `@linux.com` alias) and must not be unlinked through
-	// the normal user-initiated unlink flow.
+	// of the user (e.g. a system-managed alias such as `@linux.com`) and must
+	// not be unlinked through the normal user-initiated unlink flow.
 	SystemManaged bool `json:"system_managed,omitempty"`
 }
 

--- a/internal/infrastructure/auth0/models.go
+++ b/internal/infrastructure/auth0/models.go
@@ -23,6 +23,33 @@ type Auth0User struct {
 	Identities     []Auth0Identity    `json:"identities"`
 	AlternateEmail []Auth0ProfileData `json:"alternate_email,omitempty"`
 	UserMetadata   *Auth0UserMetadata `json:"user_metadata"`
+	AppMetadata    *Auth0AppMetadata  `json:"app_metadata,omitempty"`
+}
+
+// Auth0AppMetadata represents the application-level metadata Auth0 stores on a user.
+// Only fields relevant to this service are modeled; unknown keys are ignored.
+type Auth0AppMetadata struct {
+	// SystemManaged marks an identity that was created by this service on behalf
+	// of the user (e.g. an `@linux.com` alias) and must not be unlinked through
+	// the normal user-initiated unlink flow.
+	SystemManaged bool `json:"system_managed,omitempty"`
+}
+
+// systemManagedUserPayload is the body for POST /api/v2/users when creating a
+// stub passwordless user that will be linked as a system-managed identity.
+type systemManagedUserPayload struct {
+	Connection    string            `json:"connection"`
+	Email         string            `json:"email"`
+	EmailVerified bool              `json:"email_verified"`
+	AppMetadata   *Auth0AppMetadata `json:"app_metadata,omitempty"`
+}
+
+// linkSubIdentityPayload is the body for POST /api/v2/users/{id}/identities when
+// linking by `{provider, user_id}` (the M2M direct-link path), as opposed to the
+// passwordless `link_with` ID-token flow used by LinkIdentityPayload.
+type linkSubIdentityPayload struct {
+	Provider string `json:"provider"`
+	UserID   string `json:"user_id"`
 }
 
 // Auth0Identity represents an identity in Auth0

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -744,7 +744,16 @@ func (u *userReaderWriter) deleteSystemManagedUser(ctx context.Context, userID, 
 	)
 	var target Auth0User
 	if statusCode, errGet := apiGet.Call(ctx, &target); errGet != nil {
-		return errors.NewUnexpected(fmt.Sprintf("failed to verify system_managed before delete (status %d)", statusCode), errGet)
+		if statusCode == http.StatusNotFound {
+			// Already gone — nothing to clean up.
+			return nil
+		}
+		slog.ErrorContext(ctx, "failed to verify system-managed before delete",
+			"user_id", redaction.Redact(userID),
+			"status_code", statusCode,
+			"error", errGet,
+		)
+		return errors.NewUnexpected("failed to verify system_managed before delete", errGet)
 	}
 	if target.AppMetadata == nil || !target.AppMetadata.SystemManaged {
 		return errors.NewForbidden("refusing to delete user without app_metadata.system_managed=true")

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -557,6 +557,12 @@ func (u *userReaderWriter) AddSystemManagedEmail(ctx context.Context, primaryUse
 			"status_code", statusCode,
 			"email", redaction.RedactEmail(email),
 		)
+		// Auth0 returns 409 when the email is already registered on the
+		// connection. Surface this as a validation error so the handler can
+		// map it to alias_not_available instead of a generic infra failure.
+		if statusCode == http.StatusConflict {
+			return "", errors.NewValidation("email already linked")
+		}
 		return "", errors.NewUnexpected("failed to create system-managed stub user", errCreate)
 	}
 

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -453,10 +453,23 @@ func (u *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.Un
 	)
 
 	// Guard: refuse to unlink system-managed identities (e.g. @linux.com aliases).
-	// Fetch the stub user via M2M to read its app_metadata. The check fails closed:
-	// any error other than 404 (which means the stub never existed and there is
-	// nothing to protect) blocks the unlink so a transient Auth0 failure cannot
-	// be used to bypass immutability.
+	// Only the passwordless email connection can hold system-managed identities,
+	// so skip the guard entirely for other providers (google, github, etc.) to
+	// avoid making every social-identity unlink depend on the Management API.
+	// For email-connection unlinks, fetch the stub via M2M to read its
+	// app_metadata. The check fails closed: any error other than 404 (which
+	// means the stub never existed and there is nothing to protect) blocks the
+	// unlink so a transient Auth0 failure cannot be used to bypass immutability.
+	if request.Unlink.Provider != constants.EmailConnection {
+		return u.identityLinkingFlow.UnlinkIdentityFromUser(
+			ctx,
+			request.User.UserID,
+			request.User.AuthToken,
+			request.Unlink.Provider,
+			request.Unlink.IdentityID,
+		)
+	}
+
 	stubUserID := fmt.Sprintf("%s|%s", request.Unlink.Provider, request.Unlink.IdentityID)
 	m2mToken, errToken := u.config.M2MTokenManager.GetToken(ctx)
 	if errToken != nil {

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -578,14 +578,7 @@ func (u *userReaderWriter) AddSystemManagedEmail(ctx context.Context, primaryUse
 			"primary_user_id", redaction.Redact(primaryUserID),
 		)
 		// Best-effort rollback: delete the orphaned stub user.
-		apiDelete := httpclient.NewAPIRequest(
-			u.httpClient,
-			httpclient.WithMethod(http.MethodDelete),
-			httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s", u.config.Domain, url.PathEscape(stubUser.UserID))),
-			httpclient.WithToken(m2mToken),
-			httpclient.WithDescription("rollback: delete orphaned stub user"),
-		)
-		if _, errDel := apiDelete.Call(ctx, nil); errDel != nil {
+		if errDel := u.deleteSystemManagedUser(ctx, stubUser.UserID, m2mToken); errDel != nil {
 			slog.WarnContext(ctx, "rollback failed: could not delete orphaned stub user",
 				"error", errDel,
 				"stub_user_id", redaction.Redact(stubUser.UserID),
@@ -729,5 +722,43 @@ func (u *userReaderWriter) SetPrimaryEmail(ctx context.Context, userID string, e
 		"user_id", redaction.Redact(userID),
 	)
 
+	return nil
+}
+
+// deleteSystemManagedUser deletes an Auth0 user but only if its
+// app_metadata.system_managed is true. The pre-flight GET is defense-in-depth:
+// it ensures this helper can never be used to delete a real human account even
+// if a future caller passes the wrong user_id. A non-404 fetch failure or a
+// missing/false system_managed flag aborts the delete.
+func (u *userReaderWriter) deleteSystemManagedUser(ctx context.Context, userID, m2mToken string) error {
+	if strings.TrimSpace(userID) == "" {
+		return errors.NewValidation("user_id is required")
+	}
+
+	apiGet := httpclient.NewAPIRequest(
+		u.httpClient,
+		httpclient.WithMethod(http.MethodGet),
+		httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s", u.config.Domain, url.PathEscape(userID))),
+		httpclient.WithToken(m2mToken),
+		httpclient.WithDescription("verify system-managed before delete"),
+	)
+	var target Auth0User
+	if statusCode, errGet := apiGet.Call(ctx, &target); errGet != nil {
+		return errors.NewUnexpected(fmt.Sprintf("failed to verify system_managed before delete (status %d)", statusCode), errGet)
+	}
+	if target.AppMetadata == nil || !target.AppMetadata.SystemManaged {
+		return errors.NewForbidden("refusing to delete user without app_metadata.system_managed=true")
+	}
+
+	apiDelete := httpclient.NewAPIRequest(
+		u.httpClient,
+		httpclient.WithMethod(http.MethodDelete),
+		httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s", u.config.Domain, url.PathEscape(userID))),
+		httpclient.WithToken(m2mToken),
+		httpclient.WithDescription("delete system-managed user"),
+	)
+	if _, errDel := apiDelete.Call(ctx, nil); errDel != nil {
+		return errors.NewUnexpected("failed to delete system-managed user", errDel)
+	}
 	return nil
 }

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -53,6 +53,7 @@ type userReaderWriter struct {
 	errorResponse       *ErrorResponse
 }
 
+// SearchUser searches Auth0 for a user matching the given criteria (email, username, or user_id).
 func (u *userReaderWriter) SearchUser(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
 
 	filterer := newUserFilterer(criteria, user)
@@ -122,6 +123,7 @@ func (u *userReaderWriter) SearchUser(ctx context.Context, user *model.User, cri
 	return nil, errors.NewNotFound("user not found")
 }
 
+// GetUser fetches the full Auth0 user record by user_id.
 func (u *userReaderWriter) GetUser(ctx context.Context, user *model.User) (*model.User, error) {
 
 	slog.DebugContext(ctx, "getting user", "user_id", user.UserID)
@@ -242,6 +244,7 @@ func (u *userReaderWriter) MetadataLookup(ctx context.Context, input string, req
 	return user, nil
 }
 
+// UpdateUser applies the provided changes to the Auth0 user via PATCH.
 func (u *userReaderWriter) UpdateUser(ctx context.Context, user *model.User) (*model.User, error) {
 
 	if u.config.JWTVerificationConfig == nil {
@@ -302,6 +305,7 @@ func (u *userReaderWriter) UpdateUser(ctx context.Context, user *model.User) (*m
 	return updatedUser, nil
 }
 
+// SendVerificationAlternateEmail triggers Auth0 to send a verification link for an alternate email.
 func (u *userReaderWriter) SendVerificationAlternateEmail(ctx context.Context, alternateEmail string) error {
 
 	if u.emailLinkingFlow == nil {
@@ -318,6 +322,7 @@ func (u *userReaderWriter) SendVerificationAlternateEmail(ctx context.Context, a
 	return nil
 }
 
+// VerifyAlternateEmail completes verification of an alternate email using the provided code/token.
 func (u *userReaderWriter) VerifyAlternateEmail(ctx context.Context, email *model.Email) (*model.AuthResponse, error) {
 
 	if u.emailLinkingFlow == nil {
@@ -348,6 +353,7 @@ func (u *userReaderWriter) VerifyAlternateEmail(ctx context.Context, email *mode
 	return authResponse, nil
 }
 
+// ValidateLinkRequest performs backend-specific validation on a link-identity request before linking.
 func (u *userReaderWriter) ValidateLinkRequest(ctx context.Context, request *model.LinkIdentity) error {
 	if request == nil {
 		return errors.NewValidation("link identity request is required")
@@ -370,6 +376,7 @@ func (u *userReaderWriter) ValidateLinkRequest(ctx context.Context, request *mod
 	return nil
 }
 
+// LinkIdentity links the secondary identity in the request onto the primary Auth0 user.
 func (u *userReaderWriter) LinkIdentity(ctx context.Context, request *model.LinkIdentity) error {
 
 	if u.identityLinkingFlow == nil {
@@ -413,6 +420,7 @@ func (u *userReaderWriter) LinkIdentity(ctx context.Context, request *model.Link
 	return nil
 }
 
+// UnlinkIdentity unlinks the identity in the request from the primary Auth0 user, refusing system-managed identities.
 func (u *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.UnlinkIdentity) error {
 
 	if u.identityLinkingFlow == nil {

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -444,6 +444,36 @@ func (u *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.Un
 		"provider", request.Unlink.Provider,
 	)
 
+	// Guard: refuse to unlink system-managed identities (e.g. @linux.com aliases).
+	// Fetch the stub user via M2M to read its app_metadata.
+	stubUserID := fmt.Sprintf("%s|%s", request.Unlink.Provider, request.Unlink.IdentityID)
+	stubUser, errGetStub := u.GetUser(ctx, &model.User{UserID: stubUserID})
+	if errGetStub == nil && stubUser != nil {
+		// We need the raw app_metadata, not the domain model — re-fetch with the
+		// full Auth0User struct instead of going through ToUser() which drops it.
+		m2mToken, errToken := u.config.M2MTokenManager.GetToken(ctx)
+		if errToken != nil {
+			return errors.NewUnexpected("failed to get M2M token for unlink guard", errToken)
+		}
+		apiRequest := httpclient.NewAPIRequest(
+			u.httpClient,
+			httpclient.WithMethod(http.MethodGet),
+			httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s", u.config.Domain, url.PathEscape(stubUserID))),
+			httpclient.WithToken(m2mToken),
+			httpclient.WithDescription("get stub user for unlink guard"),
+		)
+		var rawStub Auth0User
+		if statusCode, callErr := apiRequest.Call(ctx, &rawStub); callErr != nil {
+			slog.WarnContext(ctx, "could not fetch stub user for system-managed check; allowing unlink",
+				"stub_user_id", redaction.Redact(stubUserID),
+				"status_code", statusCode,
+				"error", callErr,
+			)
+		} else if rawStub.AppMetadata != nil && rawStub.AppMetadata.SystemManaged {
+			return errors.NewForbidden("system_managed_identity")
+		}
+	}
+
 	errUnlinkIdentity := u.identityLinkingFlow.UnlinkIdentityFromUser(
 		ctx,
 		request.User.UserID,
@@ -460,6 +490,116 @@ func (u *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.Un
 	)
 
 	return nil
+}
+
+// AddSystemManagedEmail creates a stub Auth0 passwordless user for email,
+// links it to primaryUserID via the Management API (M2M, no user-facing
+// magic-link), and marks it system_managed so it cannot be user-unlinked.
+// Returns the stub user_id. On link failure a best-effort cleanup of the stub
+// is attempted before the error is returned.
+func (u *userReaderWriter) AddSystemManagedEmail(ctx context.Context, primaryUserID, email string) (string, error) {
+	if strings.TrimSpace(primaryUserID) == "" {
+		return "", errors.NewValidation("primary_user_id is required")
+	}
+	if strings.TrimSpace(email) == "" {
+		return "", errors.NewValidation("email is required")
+	}
+
+	m2mToken, errToken := u.config.M2MTokenManager.GetToken(ctx)
+	if errToken != nil {
+		return "", errors.NewUnexpected("failed to get M2M token for add system managed email", errToken)
+	}
+
+	// Step 1: create the stub passwordless user.
+	createPayload := systemManagedUserPayload{
+		Connection:    constants.EmailConnection,
+		Email:         email,
+		EmailVerified: true, // safe: LF controls the linux.com domain
+		AppMetadata:   &Auth0AppMetadata{SystemManaged: true},
+	}
+
+	apiCreate := httpclient.NewAPIRequest(
+		u.httpClient,
+		httpclient.WithMethod(http.MethodPost),
+		httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users", u.config.Domain)),
+		httpclient.WithToken(m2mToken),
+		httpclient.WithDescription("create system-managed stub user"),
+		httpclient.WithBody(createPayload),
+	)
+
+	var stubUser Auth0User
+	statusCode, errCreate := apiCreate.Call(ctx, &stubUser)
+	if errCreate != nil {
+		slog.ErrorContext(ctx, "failed to create system-managed stub user",
+			"error", errCreate,
+			"status_code", statusCode,
+			"email", redaction.RedactEmail(email),
+		)
+		return "", errors.NewUnexpected("failed to create system-managed stub user", errCreate)
+	}
+
+	if stubUser.UserID == "" {
+		return "", errors.NewUnexpected("Auth0 returned empty user_id for created stub user")
+	}
+
+	slog.DebugContext(ctx, "system-managed stub user created",
+		"stub_user_id", redaction.Redact(stubUser.UserID),
+	)
+
+	// Step 2: link the stub to the primary user.
+	// Auth0's direct-link endpoint expects the provider-local part only (without the "email|" prefix).
+	localID := stubUser.UserID
+	if idx := strings.Index(localID, "|"); idx >= 0 {
+		localID = localID[idx+1:]
+	}
+
+	linkPayload := linkSubIdentityPayload{
+		Provider: constants.EmailConnection,
+		UserID:   localID,
+	}
+
+	apiLink := httpclient.NewAPIRequest(
+		u.httpClient,
+		httpclient.WithMethod(http.MethodPost),
+		httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s/identities", u.config.Domain, url.PathEscape(primaryUserID))),
+		httpclient.WithToken(m2mToken),
+		httpclient.WithDescription("link system-managed stub to primary user"),
+		httpclient.WithBody(linkPayload),
+	)
+
+	var linkedIdentities []any
+	statusCode, errLink := apiLink.Call(ctx, &linkedIdentities)
+	if errLink != nil {
+		slog.ErrorContext(ctx, "failed to link system-managed stub to primary user; attempting rollback",
+			"error", errLink,
+			"status_code", statusCode,
+			"stub_user_id", redaction.Redact(stubUser.UserID),
+			"primary_user_id", redaction.Redact(primaryUserID),
+		)
+		// Best-effort rollback: delete the orphaned stub user.
+		apiDelete := httpclient.NewAPIRequest(
+			u.httpClient,
+			httpclient.WithMethod(http.MethodDelete),
+			httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s", u.config.Domain, url.PathEscape(stubUser.UserID))),
+			httpclient.WithToken(m2mToken),
+			httpclient.WithDescription("rollback: delete orphaned stub user"),
+		)
+		if _, errDel := apiDelete.Call(ctx, nil); errDel != nil {
+			slog.WarnContext(ctx, "rollback failed: could not delete orphaned stub user",
+				"error", errDel,
+				"stub_user_id", redaction.Redact(stubUser.UserID),
+			)
+		}
+		return "", errors.NewUnexpected("failed to link system-managed email identity", errLink)
+	}
+
+	slog.DebugContext(ctx, "system-managed email linked successfully",
+		"primary_user_id", redaction.Redact(primaryUserID),
+		"stub_user_id", redaction.Redact(stubUser.UserID),
+		"email", redaction.RedactEmail(email),
+	)
+
+	return stubUser.UserID, nil
 }
 
 // NewUserReaderWriter  creates a new UserReaderWriter with the provided configuration

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -452,7 +452,7 @@ func (u *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.Un
 		"provider", request.Unlink.Provider,
 	)
 
-	// Guard: refuse to unlink system-managed identities (e.g. @linux.com aliases).
+	// Guard: refuse to unlink system-managed identities (e.g. aliases).
 	// Only the passwordless email connection can hold system-managed identities,
 	// so skip the guard entirely for other providers (google, github, etc.) to
 	// avoid making every social-identity unlink depend on the Management API.

--- a/internal/infrastructure/auth0/user.go
+++ b/internal/infrastructure/auth0/user.go
@@ -445,33 +445,34 @@ func (u *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.Un
 	)
 
 	// Guard: refuse to unlink system-managed identities (e.g. @linux.com aliases).
-	// Fetch the stub user via M2M to read its app_metadata.
+	// Fetch the stub user via M2M to read its app_metadata. The check fails closed:
+	// any error other than 404 (which means the stub never existed and there is
+	// nothing to protect) blocks the unlink so a transient Auth0 failure cannot
+	// be used to bypass immutability.
 	stubUserID := fmt.Sprintf("%s|%s", request.Unlink.Provider, request.Unlink.IdentityID)
-	stubUser, errGetStub := u.GetUser(ctx, &model.User{UserID: stubUserID})
-	if errGetStub == nil && stubUser != nil {
-		// We need the raw app_metadata, not the domain model — re-fetch with the
-		// full Auth0User struct instead of going through ToUser() which drops it.
-		m2mToken, errToken := u.config.M2MTokenManager.GetToken(ctx)
-		if errToken != nil {
-			return errors.NewUnexpected("failed to get M2M token for unlink guard", errToken)
-		}
-		apiRequest := httpclient.NewAPIRequest(
-			u.httpClient,
-			httpclient.WithMethod(http.MethodGet),
-			httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s", u.config.Domain, url.PathEscape(stubUserID))),
-			httpclient.WithToken(m2mToken),
-			httpclient.WithDescription("get stub user for unlink guard"),
-		)
-		var rawStub Auth0User
-		if statusCode, callErr := apiRequest.Call(ctx, &rawStub); callErr != nil {
-			slog.WarnContext(ctx, "could not fetch stub user for system-managed check; allowing unlink",
+	m2mToken, errToken := u.config.M2MTokenManager.GetToken(ctx)
+	if errToken != nil {
+		return errors.NewUnexpected("failed to get M2M token for unlink guard", errToken)
+	}
+	apiRequest := httpclient.NewAPIRequest(
+		u.httpClient,
+		httpclient.WithMethod(http.MethodGet),
+		httpclient.WithURL(fmt.Sprintf("https://%s/api/v2/users/%s", u.config.Domain, url.PathEscape(stubUserID))),
+		httpclient.WithToken(m2mToken),
+		httpclient.WithDescription("get stub user for unlink guard"),
+	)
+	var rawStub Auth0User
+	if statusCode, callErr := apiRequest.Call(ctx, &rawStub); callErr != nil {
+		if statusCode != http.StatusNotFound {
+			slog.ErrorContext(ctx, "failed to evaluate system-managed unlink guard",
 				"stub_user_id", redaction.Redact(stubUserID),
 				"status_code", statusCode,
 				"error", callErr,
 			)
-		} else if rawStub.AppMetadata != nil && rawStub.AppMetadata.SystemManaged {
-			return errors.NewForbidden("system_managed_identity")
+			return errors.NewUnexpected("failed to evaluate system-managed unlink guard", callErr)
 		}
+	} else if rawStub.AppMetadata != nil && rawStub.AppMetadata.SystemManaged {
+		return errors.NewForbidden("system_managed_identity")
 	}
 
 	errUnlinkIdentity := u.identityLinkingFlow.UnlinkIdentityFromUser(

--- a/internal/infrastructure/auth0/user_test.go
+++ b/internal/infrastructure/auth0/user_test.go
@@ -759,6 +759,119 @@ func TestUserReaderWriter_MetadataLookup(t *testing.T) {
 	}
 }
 
+func TestUserReaderWriter_AddSystemManagedEmail_Validation(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		primaryUserID string
+		email         string
+		wantErrMsg    string
+	}{
+		{
+			name:          "empty primaryUserID",
+			primaryUserID: "",
+			email:         "jdoe@linux.com",
+			wantErrMsg:    "primary_user_id is required",
+		},
+		{
+			name:          "whitespace-only primaryUserID",
+			primaryUserID: "   ",
+			email:         "jdoe@linux.com",
+			wantErrMsg:    "primary_user_id is required",
+		},
+		{
+			name:          "empty email",
+			primaryUserID: "auth0|test123",
+			email:         "",
+			wantErrMsg:    "email is required",
+		},
+		{
+			name:          "whitespace-only email",
+			primaryUserID: "auth0|test123",
+			email:         "   ",
+			wantErrMsg:    "email is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := &userReaderWriter{
+				httpClient: httpclient.NewClient(httpclient.DefaultConfig()),
+				config: Config{
+					Tenant: "test-tenant",
+					Domain: "test-tenant.auth0.com",
+				},
+			}
+
+			stubID, err := rw.AddSystemManagedEmail(ctx, tt.primaryUserID, tt.email)
+
+			require.Error(t, err, "expected validation error")
+			assert.Empty(t, stubID)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+		})
+	}
+}
+
+func TestUserReaderWriter_UnlinkIdentity_ValidationGuard(t *testing.T) {
+	ctx := context.Background()
+
+	rw := &userReaderWriter{
+		httpClient:          httpclient.NewClient(httpclient.DefaultConfig()),
+		identityLinkingFlow: newIdentityLinkingFlow("test-tenant.auth0.com", httpclient.NewClient(httpclient.DefaultConfig())),
+		config: Config{
+			Tenant: "test-tenant",
+			Domain: "test-tenant.auth0.com",
+		},
+	}
+
+	makeRequest := func(raw string) *model.UnlinkIdentity {
+		var req model.UnlinkIdentity
+		_ = json.Unmarshal([]byte(raw), &req)
+		return &req
+	}
+
+	tests := []struct {
+		name       string
+		request    *model.UnlinkIdentity
+		wantErrMsg string
+	}{
+		{
+			name:       "nil request",
+			request:    nil,
+			wantErrMsg: "unlink identity request is required",
+		},
+		{
+			name:       "missing user_id",
+			request:    makeRequest(`{"user":{"auth_token":"tok"},"unlink":{"provider":"google-oauth2","identity_id":"123"}}`),
+			wantErrMsg: "user_id is required",
+		},
+		{
+			name:       "missing auth_token",
+			request:    makeRequest(`{"user":{"user_id":"auth0|abc"},"unlink":{"provider":"google-oauth2","identity_id":"123"}}`),
+			wantErrMsg: "user_token is required",
+		},
+		{
+			name:       "missing provider",
+			request:    makeRequest(`{"user":{"user_id":"auth0|abc","auth_token":"tok"},"unlink":{"identity_id":"123"}}`),
+			wantErrMsg: "provider is required",
+		},
+		{
+			name:       "missing identity_id",
+			request:    makeRequest(`{"user":{"user_id":"auth0|abc","auth_token":"tok"},"unlink":{"provider":"google-oauth2"}}`),
+			wantErrMsg: "identity_id is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rw.UnlinkIdentity(ctx, tt.request)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+		})
+	}
+}
+
 // Helper function to check if a string contains a substring
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr ||

--- a/internal/infrastructure/authelia/user.go
+++ b/internal/infrastructure/authelia/user.go
@@ -277,6 +277,7 @@ func (a *userReaderWriter) UpdateUser(ctx context.Context, user *model.User) (*m
 	return existingUser.User, nil
 }
 
+// SendVerificationAlternateEmail triggers an email verification link via the Authelia backend.
 func (a *userReaderWriter) SendVerificationAlternateEmail(ctx context.Context, alternateEmail string) error {
 	slog.DebugContext(ctx, "sending alternate email verification",
 		"alternate_email", redaction.RedactEmail(alternateEmail),
@@ -307,6 +308,7 @@ func (a *userReaderWriter) SendVerificationAlternateEmail(ctx context.Context, a
 	return nil
 }
 
+// VerifyAlternateEmail completes verification of an alternate email for an Authelia-backed user.
 func (a *userReaderWriter) VerifyAlternateEmail(ctx context.Context, email *model.Email) (*model.AuthResponse, error) {
 
 	if email.Email == "" || email.OTP == "" {
@@ -350,11 +352,13 @@ func (a *userReaderWriter) VerifyAlternateEmail(ctx context.Context, email *mode
 	}, nil
 }
 
+// ValidateLinkRequest is a no-op for Authelia; link requests are validated implicitly by LinkIdentity.
 func (a *userReaderWriter) ValidateLinkRequest(ctx context.Context, _ *model.LinkIdentity) error {
 	slog.DebugContext(ctx, "no validations for authelia request")
 	return nil
 }
 
+// LinkIdentity links a secondary identity onto an Authelia-backed primary user.
 func (a *userReaderWriter) LinkIdentity(ctx context.Context, request *model.LinkIdentity) error {
 	if request == nil {
 		return errs.NewValidation("request is required")
@@ -490,6 +494,7 @@ func (a *userReaderWriter) linkSocialIdentity(ctx context.Context, request *mode
 	return nil
 }
 
+// UnlinkIdentity unlinks an identity from an Authelia-backed primary user.
 func (a *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.UnlinkIdentity) error {
 	if request == nil {
 		return errs.NewValidation("request is required")
@@ -541,14 +546,17 @@ func (a *userReaderWriter) UnlinkIdentity(ctx context.Context, request *model.Un
 	return nil
 }
 
+// ChangePassword is not supported for Authelia users.
 func (a *userReaderWriter) ChangePassword(_ context.Context, _ *model.User, _, _ string) error {
 	return errs.NewValidation("password change is not supported for Authelia users")
 }
 
+// SendResetPasswordLink is not supported for Authelia users.
 func (a *userReaderWriter) SendResetPasswordLink(_ context.Context, _ *model.User) error {
 	return errs.NewValidation("password reset link is not supported for Authelia users")
 }
 
+// SetPrimaryEmail is not supported for Authelia users.
 func (a *userReaderWriter) SetPrimaryEmail(_ context.Context, _ string, _ string) error {
 	return errs.NewValidation("set primary email is not supported for Authelia users")
 }

--- a/internal/infrastructure/authelia/user.go
+++ b/internal/infrastructure/authelia/user.go
@@ -553,6 +553,12 @@ func (a *userReaderWriter) SetPrimaryEmail(_ context.Context, _ string, _ string
 	return errs.NewValidation("set primary email is not supported for Authelia users")
 }
 
+// AddSystemManagedEmail is not supported for Authelia users; system-managed
+// aliases require the Auth0 Management API backend.
+func (a *userReaderWriter) AddSystemManagedEmail(_ context.Context, _, _ string) (string, error) {
+	return "", errs.NewValidation("add system managed email is not supported for Authelia users")
+}
+
 // NewUserReaderWriter creates a new Authelia User repository
 func NewUserReaderWriter(ctx context.Context, config map[string]string, natsClient *nats.NATSClient) (port.UserReaderWriter, error) {
 	// Set defaults in case of not set

--- a/internal/infrastructure/mock/user.go
+++ b/internal/infrastructure/mock/user.go
@@ -476,6 +476,15 @@ func (u *userWriter) UnlinkIdentity(ctx context.Context, request *model.UnlinkId
 
 	switch request.Unlink.Provider {
 	case "email":
+		// Parity with the Auth0 adapter: an email-connection entry in
+		// user.Identities is by construction a system-managed alias (only
+		// AddSystemManagedEmail writes there). Refuse to unlink it so the
+		// mock enforces the same immutability invariant as Auth0.
+		for _, id := range user.Identities {
+			if id.Provider == "email" && strings.EqualFold(id.Email, request.Unlink.IdentityID) {
+				return errors.NewForbidden("system_managed_identity")
+			}
+		}
 		user.AlternateEmails = collections.RemoveFromSlice(user.AlternateEmails, func(e model.Email) bool {
 			return strings.EqualFold(e.Email, request.Unlink.IdentityID)
 		})

--- a/internal/infrastructure/mock/user.go
+++ b/internal/infrastructure/mock/user.go
@@ -62,6 +62,7 @@ func loadUsersFromYAML(ctx context.Context) ([]*model.User, error) {
 	return users, nil
 }
 
+// GetUser fetches a user from the in-memory mock store by user_id.
 func (u *userWriter) GetUser(ctx context.Context, user *model.User) (*model.User, error) {
 	slog.InfoContext(ctx, "mock: getting user", "user", user)
 
@@ -92,6 +93,7 @@ func (u *userWriter) GetUser(ctx context.Context, user *model.User) (*model.User
 	return nil, errors.NewNotFound("user not found")
 }
 
+// SearchUser searches the in-memory mock store for a user matching the given criteria.
 func (u *userWriter) SearchUser(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
 	slog.InfoContext(ctx, "mock: searching user", "user", user, "criteria", criteria)
 
@@ -112,6 +114,7 @@ func (u *userWriter) SearchUser(ctx context.Context, user *model.User, criteria 
 	return result, nil
 }
 
+// UpdateUser applies the provided changes to a mock user record.
 func (u *userWriter) UpdateUser(ctx context.Context, user *model.User) (*model.User, error) {
 	slog.InfoContext(ctx, "mock: updating user", "user", user)
 
@@ -219,6 +222,7 @@ func (u *userWriter) UpdateUser(ctx context.Context, user *model.User) (*model.U
 	return &updatedUser, nil
 }
 
+// SendVerificationAlternateEmail is a no-op in the mock adapter.
 func (u *userWriter) SendVerificationAlternateEmail(ctx context.Context, alternateEmail string) error {
 	slog.DebugContext(ctx, "mock: sending alternate email verification", "alternate_email", redaction.Redact(alternateEmail))
 
@@ -266,6 +270,7 @@ func (u *userWriter) SendVerificationAlternateEmail(ctx context.Context, alterna
 	return nil
 }
 
+// VerifyAlternateEmail simulates verifying an alternate email in the mock store.
 func (u *userWriter) VerifyAlternateEmail(ctx context.Context, email *model.Email) (*model.AuthResponse, error) {
 	slog.DebugContext(ctx, "mock: verifying alternate email", "email", redaction.Redact(email.Email))
 
@@ -338,11 +343,13 @@ func (u *userWriter) VerifyAlternateEmail(ctx context.Context, email *model.Emai
 	}, nil
 }
 
+// ValidateLinkRequest is a no-op in the mock adapter.
 func (u *userWriter) ValidateLinkRequest(ctx context.Context, _ *model.LinkIdentity) error {
 	slog.DebugContext(ctx, "no validations for mock request")
 	return nil
 }
 
+// LinkIdentity links a secondary identity onto a mock primary user.
 func (u *userWriter) LinkIdentity(ctx context.Context, request *model.LinkIdentity) error {
 	slog.DebugContext(ctx, "mock: linking identity")
 
@@ -450,6 +457,7 @@ func (u *userWriter) linkSocialIdentity(ctx context.Context, request *model.Link
 	return nil
 }
 
+// UnlinkIdentity unlinks an identity from a mock primary user.
 func (u *userWriter) UnlinkIdentity(ctx context.Context, request *model.UnlinkIdentity) error {
 	slog.DebugContext(ctx, "mock: unlinking identity")
 
@@ -488,6 +496,7 @@ func (u *userWriter) UnlinkIdentity(ctx context.Context, request *model.UnlinkId
 	return nil
 }
 
+// ChangePassword updates the password for a mock user.
 func (u *userWriter) ChangePassword(ctx context.Context, user *model.User, currentPassword, newPassword string) error {
 	if user == nil {
 		return errors.NewValidation("user is required")
@@ -498,6 +507,7 @@ func (u *userWriter) ChangePassword(ctx context.Context, user *model.User, curre
 	return nil
 }
 
+// SendResetPasswordLink is a no-op in the mock adapter.
 func (u *userWriter) SendResetPasswordLink(ctx context.Context, user *model.User) error {
 	if user == nil {
 		return errors.NewValidation("user is required")
@@ -508,6 +518,7 @@ func (u *userWriter) SendResetPasswordLink(ctx context.Context, user *model.User
 	return nil
 }
 
+// SetPrimaryEmail updates the primary email on a mock user.
 func (u *userWriter) SetPrimaryEmail(ctx context.Context, userID string, email string) error {
 	slog.DebugContext(ctx, "mock: setting primary email",
 		"user_id", redaction.Redact(userID),
@@ -574,6 +585,7 @@ func (u *userWriter) AddSystemManagedEmail(_ context.Context, primaryUserID, ema
 	return stubID, nil
 }
 
+// MetadataLookup resolves a user via metadata lookup in the mock store.
 func (u *userWriter) MetadataLookup(ctx context.Context, input string, requiredScopes ...string) (*model.User, error) {
 	slog.DebugContext(ctx, "mock: metadata lookup", "input", redaction.Redact(input))
 

--- a/internal/infrastructure/mock/user.go
+++ b/internal/infrastructure/mock/user.go
@@ -550,6 +550,25 @@ func (u *userWriter) SetPrimaryEmail(ctx context.Context, userID string, email s
 	return nil
 }
 
+// AddSystemManagedEmail is a no-op stub for the mock adapter. It records the
+// email as a verified linked identity on the user so tests can verify it
+// surfaces in GetUserEmails / user_emails.read.
+func (u *userWriter) AddSystemManagedEmail(_ context.Context, primaryUserID, email string) (string, error) {
+	user, exists := u.users[primaryUserID]
+	if !exists {
+		return "", errors.NewNotFound("user not found")
+	}
+	stubID := "email|mock-" + email
+	user.Identities = append(user.Identities, model.Identity{
+		Provider:      "email",
+		IdentityID:    "mock-" + email,
+		Connection:    "email",
+		Email:         email,
+		EmailVerified: true,
+	})
+	return stubID, nil
+}
+
 func (u *userWriter) MetadataLookup(ctx context.Context, input string, requiredScopes ...string) (*model.User, error) {
 	slog.DebugContext(ctx, "mock: metadata lookup", "input", redaction.Redact(input))
 

--- a/internal/infrastructure/mock/user.go
+++ b/internal/infrastructure/mock/user.go
@@ -559,6 +559,11 @@ func (u *userWriter) AddSystemManagedEmail(_ context.Context, primaryUserID, ema
 		return "", errors.NewNotFound("user not found")
 	}
 	stubID := "email|mock-" + email
+	for _, id := range user.Identities {
+		if id.Provider == "email" && strings.EqualFold(id.Email, email) {
+			return "", errors.NewValidation("email is already linked")
+		}
+	}
 	user.Identities = append(user.Identities, model.Identity{
 		Provider:      "email",
 		IdentityID:    "mock-" + email,

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -46,6 +47,7 @@ type messageHandlerOrchestrator struct {
 	passwordHandler  port.PasswordHandler
 	impersonator     port.Impersonator
 	eventPublisher   port.EventPublisher
+	aliasManager     port.AliasManager
 }
 
 // MessageHandlerOrchestratorOption defines a function type for setting options
@@ -104,6 +106,13 @@ func WithImpersonatorForMessageHandler(impersonator port.Impersonator) MessageHa
 func WithEventPublisherForMessageHandler(eventPublisher port.EventPublisher) MessageHandlerOrchestratorOption {
 	return func(m *messageHandlerOrchestrator) {
 		m.eventPublisher = eventPublisher
+	}
+}
+
+// WithAliasManagerForMessageHandler sets the alias manager for the message handler orchestrator
+func WithAliasManagerForMessageHandler(aliasManager port.AliasManager) MessageHandlerOrchestratorOption {
+	return func(m *messageHandlerOrchestrator) {
+		m.aliasManager = aliasManager
 	}
 }
 
@@ -892,6 +901,118 @@ func (m *messageHandlerOrchestrator) ImpersonateUser(ctx context.Context, msg po
 	}
 
 	return responseJSON, nil
+}
+
+// addLcomAliasRequest is the JSON payload for lfx.auth-service.add_lcom_alias
+type addLcomAliasRequest struct {
+	User struct {
+		AuthToken string `json:"auth_token"`
+	} `json:"user"`
+	Alias string `json:"alias"`
+}
+
+// addLcomAliasResponse is the reply for lfx.auth-service.add_lcom_alias
+type addLcomAliasResponse struct {
+	Success bool   `json:"success"`
+	Email   string `json:"email,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// AddLcomAlias claims an @linux.com alias for the authenticated caller by
+// creating a system-managed Auth0 linked identity via the Management API.
+//
+// Flow:
+//  1. Validate JWT (UserUpdateIdentityRequiredScope), extract sub.
+//  2. Reject if caller already has a @linux.com identity (already_claimed).
+//  3. Validate alias local part (alias_invalid / alias_reserved).
+//  4. Search Auth0 to ensure the full address isn't already taken (alias_not_available).
+//  5. Call AddSystemManagedEmail and return the confirmed address.
+func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
+	if m.aliasManager == nil {
+		return m.errorResponse("alias service unavailable"), nil
+	}
+	if m.userReader == nil {
+		return m.errorResponse("auth service unavailable"), nil
+	}
+
+	var request addLcomAliasRequest
+	if err := json.Unmarshal(msg.Data(), &request); err != nil {
+		return m.errorResponse("failed to unmarshal request"), nil
+	}
+
+	authToken := strings.TrimSpace(request.User.AuthToken)
+	if authToken == "" {
+		return m.errorResponse("auth_token is required"), nil
+	}
+
+	user, errLookup := m.userReader.MetadataLookup(ctx, authToken, constants.UserUpdateIdentityRequiredScope)
+	if errLookup != nil {
+		return m.errorResponse(errLookup.Error()), nil
+	}
+
+	fullUser, errGetUser := m.userReader.GetUser(ctx, user)
+	if errGetUser != nil {
+		return m.errorResponse(errGetUser.Error()), nil
+	}
+
+	// Check if the user already has a @linux.com identity.
+	for _, id := range fullUser.Identities {
+		if id.Connection == constants.EmailConnection && strings.HasSuffix(strings.ToLower(id.Email), "@linux.com") {
+			return m.errorResponse("already_claimed"), nil
+		}
+	}
+	for _, alt := range fullUser.AlternateEmails {
+		if strings.HasSuffix(strings.ToLower(alt.Email), "@linux.com") {
+			return m.errorResponse("already_claimed"), nil
+		}
+	}
+
+	// Parse optional extra reserved names from env (comma-separated).
+	var extraReserved []string
+	if raw := strings.TrimSpace(os.Getenv(constants.LcomAliasReservedExtraEnvKey)); raw != "" {
+		for _, n := range strings.Split(raw, ",") {
+			if trimmed := strings.TrimSpace(n); trimmed != "" {
+				extraReserved = append(extraReserved, trimmed)
+			}
+		}
+	}
+
+	normalised, errCode := model.ValidateLcomAlias(request.Alias, extraReserved)
+	if errCode != "" {
+		return m.errorResponse(errCode), nil
+	}
+
+	fullEmail := normalised + "@linux.com"
+
+	// Verify the address isn't already claimed in Auth0.
+	if errExists := m.checkEmailExists(ctx, fullEmail); errExists != nil {
+		slog.DebugContext(ctx, "alias already exists in Auth0",
+			"email", redaction.RedactEmail(fullEmail),
+		)
+		return m.errorResponse("alias_not_available"), nil
+	}
+
+	stubID, errAdd := m.aliasManager.AddSystemManagedEmail(ctx, fullUser.UserID, fullEmail)
+	if errAdd != nil {
+		slog.ErrorContext(ctx, "failed to add system-managed email",
+			"error", errAdd,
+			"user_id", redaction.Redact(fullUser.UserID),
+			"email", redaction.RedactEmail(fullEmail),
+		)
+		return m.errorResponse(errAdd.Error()), nil
+	}
+
+	slog.DebugContext(ctx, "lcom alias claimed successfully",
+		"user_id", redaction.Redact(fullUser.UserID),
+		"stub_id", redaction.Redact(stubID),
+		"email", redaction.RedactEmail(fullEmail),
+	)
+
+	resp, err := json.Marshal(addLcomAliasResponse{Success: true, Email: fullEmail})
+	if err != nil {
+		return m.errorResponse("failed to marshal response"), nil
+	}
+	return resp, nil
 }
 
 // NewMessageHandlerOrchestrator creates a new message handler orchestrator using the option pattern

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -903,31 +903,34 @@ func (m *messageHandlerOrchestrator) ImpersonateUser(ctx context.Context, msg po
 	return responseJSON, nil
 }
 
-// addLcomAliasRequest is the JSON payload for lfx.auth-service.add_lcom_alias
-type addLcomAliasRequest struct {
+// addAliasRequest is the JSON payload for lfx.auth-service.add_alias
+type addAliasRequest struct {
 	User struct {
 		AuthToken string `json:"auth_token"`
 	} `json:"user"`
-	Alias string `json:"alias"`
+	Alias  string `json:"alias"`
+	Domain string `json:"domain"`
 }
 
-// addLcomAliasResponse is the reply for lfx.auth-service.add_lcom_alias
-type addLcomAliasResponse struct {
+// addAliasResponse is the reply for lfx.auth-service.add_alias
+type addAliasResponse struct {
 	Success bool   `json:"success"`
 	Email   string `json:"email,omitempty"`
 	Error   string `json:"error,omitempty"`
 }
 
-// AddLcomAlias claims an @linux.com alias for the authenticated caller by
-// creating a system-managed Auth0 linked identity via the Management API.
+// AddAlias claims a system-managed alias on a caller-supplied domain (e.g.
+// @linux.com) by creating a passwordless Auth0 stub user and linking it via
+// the Management API.
 //
 // Flow:
 //  1. Validate JWT (UserUpdateIdentityRequiredScope), extract sub.
-//  2. Reject if caller already has a @linux.com identity (already_claimed).
-//  3. Validate alias local part (alias_invalid / alias_reserved).
-//  4. Search Auth0 to ensure the full address isn't already taken (alias_not_available).
-//  5. Call AddSystemManagedEmail and return the confirmed address.
-func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
+//  2. Validate the requested domain is in ALLOWED_ALIAS_DOMAINS.
+//  3. Reject if caller already has an alias on this domain (already_claimed).
+//  4. Validate alias local part (alias_invalid / alias_reserved).
+//  5. Search Auth0 to ensure the full address isn't already taken (alias_not_available).
+//  6. Call AddSystemManagedEmail and return the confirmed address.
+func (m *messageHandlerOrchestrator) AddAlias(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 	if m.aliasManager == nil {
 		return m.errorResponse("alias service unavailable"), nil
 	}
@@ -935,7 +938,7 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 		return m.errorResponse("auth service unavailable"), nil
 	}
 
-	var request addLcomAliasRequest
+	var request addAliasRequest
 	if err := json.Unmarshal(msg.Data(), &request); err != nil {
 		return m.errorResponse("failed to unmarshal request"), nil
 	}
@@ -943,6 +946,25 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 	authToken := strings.TrimSpace(request.User.AuthToken)
 	if authToken == "" {
 		return m.errorResponse("auth_token is required"), nil
+	}
+
+	// Validate the requested domain against the server-side allow-list.
+	// Empty/unset env means the feature is disabled — fail closed.
+	requestedDomain := strings.ToLower(strings.TrimSpace(request.Domain))
+	if requestedDomain == "" {
+		return m.errorResponse("domain_not_allowed"), nil
+	}
+	allowed := false
+	if raw := strings.TrimSpace(os.Getenv(constants.AllowedAliasDomainsEnvKey)); raw != "" {
+		for _, d := range strings.Split(raw, ",") {
+			if strings.EqualFold(requestedDomain, strings.TrimSpace(d)) {
+				allowed = true
+				break
+			}
+		}
+	}
+	if !allowed {
+		return m.errorResponse("domain_not_allowed"), nil
 	}
 
 	user, errLookup := m.userReader.MetadataLookup(ctx, authToken, constants.UserUpdateIdentityRequiredScope)
@@ -955,25 +977,27 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 		return m.errorResponse(errGetUser.Error()), nil
 	}
 
-	// Check if the user already has a @linux.com identity. Cover all three
-	// surfaces: primary email, linked identities, and alternate emails.
-	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(fullUser.PrimaryEmail)), "@linux.com") {
+	// Already-claimed check is scoped to the requested domain: a user may
+	// hold at most one alias per allowed domain. Cover all three surfaces:
+	// primary email, linked identities, and alternate emails.
+	domainSuffix := "@" + requestedDomain
+	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(fullUser.PrimaryEmail)), domainSuffix) {
 		return m.errorResponse("already_claimed"), nil
 	}
 	for _, id := range fullUser.Identities {
-		if id.Connection == constants.EmailConnection && strings.HasSuffix(strings.ToLower(id.Email), "@linux.com") {
+		if id.Connection == constants.EmailConnection && strings.HasSuffix(strings.ToLower(id.Email), domainSuffix) {
 			return m.errorResponse("already_claimed"), nil
 		}
 	}
 	for _, alt := range fullUser.AlternateEmails {
-		if strings.HasSuffix(strings.ToLower(alt.Email), "@linux.com") {
+		if strings.HasSuffix(strings.ToLower(alt.Email), domainSuffix) {
 			return m.errorResponse("already_claimed"), nil
 		}
 	}
 
 	// Parse optional extra reserved names from env (comma-separated).
 	var extraReserved []string
-	if raw := strings.TrimSpace(os.Getenv(constants.LcomAliasReservedExtraEnvKey)); raw != "" {
+	if raw := strings.TrimSpace(os.Getenv(constants.AliasReservedExtraEnvKey)); raw != "" {
 		for _, n := range strings.Split(raw, ",") {
 			if trimmed := strings.TrimSpace(n); trimmed != "" {
 				extraReserved = append(extraReserved, trimmed)
@@ -981,12 +1005,12 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 		}
 	}
 
-	normalised, errCode := model.ValidateLcomAlias(request.Alias, extraReserved)
+	normalised, errCode := model.ValidateAlias(request.Alias, requestedDomain, extraReserved)
 	if errCode != "" {
 		return m.errorResponse(errCode), nil
 	}
 
-	fullEmail := normalised + "@linux.com"
+	fullEmail := normalised + domainSuffix
 
 	// Verify the address isn't already claimed in Auth0. checkEmailExists
 	// returns errs.Validation ("email already linked") for a true conflict and
@@ -1030,13 +1054,13 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 		return m.errorResponse(errAdd.Error()), nil
 	}
 
-	slog.DebugContext(ctx, "lcom alias claimed successfully",
+	slog.DebugContext(ctx, "alias claimed successfully",
 		"user_id", redaction.Redact(fullUser.UserID),
 		"stub_id", redaction.Redact(stubID),
 		"email", redaction.RedactEmail(fullEmail),
 	)
 
-	resp, err := json.Marshal(addLcomAliasResponse{Success: true, Email: fullEmail})
+	resp, err := json.Marshal(addAliasResponse{Success: true, Email: fullEmail})
 	if err != nil {
 		return m.errorResponse("failed to marshal response"), nil
 	}

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -955,7 +955,11 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 		return m.errorResponse(errGetUser.Error()), nil
 	}
 
-	// Check if the user already has a @linux.com identity.
+	// Check if the user already has a @linux.com identity. Cover all three
+	// surfaces: primary email, linked identities, and alternate emails.
+	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(fullUser.PrimaryEmail)), "@linux.com") {
+		return m.errorResponse("already_claimed"), nil
+	}
 	for _, id := range fullUser.Identities {
 		if id.Connection == constants.EmailConnection && strings.HasSuffix(strings.ToLower(id.Email), "@linux.com") {
 			return m.errorResponse("already_claimed"), nil
@@ -984,12 +988,24 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 
 	fullEmail := normalised + "@linux.com"
 
-	// Verify the address isn't already claimed in Auth0.
+	// Verify the address isn't already claimed in Auth0. checkEmailExists
+	// returns errs.Validation ("email already linked") for a true conflict and
+	// propagates other errors (e.g. Auth0 search outage) — only the former
+	// should be surfaced as alias_not_available, otherwise we'd mask infra
+	// failures behind a misleading user-facing code.
 	if errExists := m.checkEmailExists(ctx, fullEmail); errExists != nil {
-		slog.DebugContext(ctx, "alias already exists in Auth0",
+		var validationErr errs.Validation
+		if errors.As(errExists, &validationErr) {
+			slog.DebugContext(ctx, "alias already exists in Auth0",
+				"email", redaction.RedactEmail(fullEmail),
+			)
+			return m.errorResponse("alias_not_available"), nil
+		}
+		slog.ErrorContext(ctx, "failed to verify alias availability",
+			"error", errExists,
 			"email", redaction.RedactEmail(fullEmail),
 		)
-		return m.errorResponse("alias_not_available"), nil
+		return m.errorResponse(errExists.Error()), nil
 	}
 
 	stubID, errAdd := m.aliasManager.AddSystemManagedEmail(ctx, fullUser.UserID, fullEmail)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -133,7 +133,7 @@ func (m *messageHandlerOrchestrator) errorResponse(error string) []byte {
 // searchByEmail normalizes the email (lowercases and trims whitespace) and returns the matching user or an error
 func (m *messageHandlerOrchestrator) searchByEmail(ctx context.Context, criteria string, email string) (*model.User, error) {
 	if m.userReader == nil {
-		return nil, errs.NewUnexpected("auth service unavailable")
+		return nil, errs.NewUnexpected("auth_service_unavailable")
 	}
 
 	slog.DebugContext(ctx, "search by email",
@@ -201,7 +201,7 @@ func (m *messageHandlerOrchestrator) UsernameToSub(_ context.Context, msg port.T
 
 func (m *messageHandlerOrchestrator) getUserByInput(ctx context.Context, msg port.TransportMessenger) (*model.User, error) {
 	if m.userReader == nil {
-		return nil, errs.NewUnexpected("auth service unavailable")
+		return nil, errs.NewUnexpected("auth_service_unavailable")
 	}
 
 	input := strings.TrimSpace(string(msg.Data()))
@@ -270,12 +270,12 @@ type userEmailsRequest struct {
 func (m *messageHandlerOrchestrator) GetUserEmails(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 
 	if m.userReader == nil {
-		return m.errorResponse("auth service unavailable"), nil
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	var request userEmailsRequest
 	if err := json.Unmarshal(msg.Data(), &request); err != nil {
-		return m.errorResponse("failed to unmarshal request"), nil
+		return m.errorResponse("failed_to_unmarshal_request"), nil
 	}
 
 	authToken := strings.TrimSpace(request.User.AuthToken)
@@ -356,12 +356,12 @@ type identityProfileData struct {
 func (m *messageHandlerOrchestrator) ListIdentities(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 
 	if m.userReader == nil {
-		return m.errorResponse("auth service unavailable"), nil
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	var request identityListRequest
 	if err := json.Unmarshal(msg.Data(), &request); err != nil {
-		return m.errorResponse("failed to unmarshal request"), nil
+		return m.errorResponse("failed_to_unmarshal_request"), nil
 	}
 
 	authToken := strings.TrimSpace(request.User.AuthToken)
@@ -424,7 +424,7 @@ func (m *messageHandlerOrchestrator) ListIdentities(ctx context.Context, msg por
 func (m *messageHandlerOrchestrator) UpdateUser(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 
 	if m.userWriter == nil {
-		return m.errorResponse("auth service unavailable"), nil
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	user := &model.User{}
@@ -619,13 +619,13 @@ func (m *messageHandlerOrchestrator) VerifyEmailLinking(ctx context.Context, msg
 func (m *messageHandlerOrchestrator) LinkIdentity(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 
 	if m.identityLinker == nil {
-		slog.ErrorContext(ctx, "auth service unavailable")
-		return m.errorResponse("auth service unavailable"), nil
+		slog.ErrorContext(ctx, "auth_service_unavailable")
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	if m.userReader == nil {
-		slog.ErrorContext(ctx, "auth service unavailable")
-		return m.errorResponse("auth service unavailable"), nil
+		slog.ErrorContext(ctx, "auth_service_unavailable")
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	linkRequest := &model.LinkIdentity{}
@@ -673,11 +673,11 @@ func (m *messageHandlerOrchestrator) LinkIdentity(ctx context.Context, msg port.
 func (m *messageHandlerOrchestrator) UnlinkIdentity(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 
 	if m.identityUnlinker == nil {
-		return m.errorResponse("auth service unavailable"), nil
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	if m.userReader == nil {
-		return m.errorResponse("auth service unavailable"), nil
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	unlinkRequest := &model.UnlinkIdentity{}
@@ -806,7 +806,7 @@ type setPrimaryEmailRequest struct {
 func (m *messageHandlerOrchestrator) SetPrimaryEmail(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 
 	if m.userWriter == nil || m.userReader == nil {
-		return m.errorResponse("auth service unavailable"), nil
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	var request setPrimaryEmailRequest
@@ -932,15 +932,15 @@ type addAliasResponse struct {
 //  6. Call AddSystemManagedEmail and return the confirmed address.
 func (m *messageHandlerOrchestrator) AddAlias(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 	if m.aliasManager == nil {
-		return m.errorResponse("alias service unavailable"), nil
+		return m.errorResponse("alias_service_unavailable"), nil
 	}
 	if m.userReader == nil {
-		return m.errorResponse("auth service unavailable"), nil
+		return m.errorResponse("auth_service_unavailable"), nil
 	}
 
 	var request addAliasRequest
 	if err := json.Unmarshal(msg.Data(), &request); err != nil {
-		return m.errorResponse("failed to unmarshal request"), nil
+		return m.errorResponse("failed_to_unmarshal_request"), nil
 	}
 
 	authToken := strings.TrimSpace(request.User.AuthToken)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -1010,6 +1010,18 @@ func (m *messageHandlerOrchestrator) AddLcomAlias(ctx context.Context, msg port.
 
 	stubID, errAdd := m.aliasManager.AddSystemManagedEmail(ctx, fullUser.UserID, fullEmail)
 	if errAdd != nil {
+		// A validation error here means the address was claimed between the
+		// availability check above and the stub creation (TOCTOU race) — map
+		// to the stable alias_not_available code instead of leaking the raw
+		// backend message. Operational failures still propagate.
+		var validationErr errs.Validation
+		if errors.As(errAdd, &validationErr) {
+			slog.DebugContext(ctx, "alias became unavailable during claim",
+				"user_id", redaction.Redact(fullUser.UserID),
+				"email", redaction.RedactEmail(fullEmail),
+			)
+			return m.errorResponse("alias_not_available"), nil
+		}
 		slog.ErrorContext(ctx, "failed to add system-managed email",
 			"error", errAdd,
 			"user_id", redaction.Redact(fullUser.UserID),

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -3260,6 +3260,39 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 		}
 	})
 
+	t.Run("availability lookup operational error is propagated, not alias_not_available", func(t *testing.T) {
+		alias := &mockAliasManager{}
+		reader := &mockUserServiceReader{
+			metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+				return &model.User{UserID: userID}, nil
+			},
+			getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{UserID: userID}, nil
+			},
+			searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+				return nil, errors.NewUnexpected("search backend unavailable", nil)
+			},
+		}
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(reader),
+			WithAliasManagerForMessageHandler(alias),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] == "alias_not_available" {
+			t.Errorf("operational error must not be masked as alias_not_available")
+		}
+		if reply["error"] == nil || reply["error"] == "" {
+			t.Errorf("expected propagated lookup error, got %v", reply)
+		}
+		if len(alias.calledWith) != 0 {
+			t.Error("AddSystemManagedEmail must not be called when availability lookup fails")
+		}
+	})
+
 	t.Run("AddSystemManagedEmail fails — error propagated", func(t *testing.T) {
 		alias := &mockAliasManager{
 			addSystemManagedEmailFunc: func(ctx context.Context, primaryUserID, email string) (string, error) {

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -667,8 +667,8 @@ func TestMessageHandlerOrchestrator_EmailToUsername_NoUserReader(t *testing.T) {
 		t.Error("Expected success=false when user reader is nil")
 	}
 
-	if response.Error != "auth service unavailable" {
-		t.Errorf("Expected error 'auth service unavailable', got %s", response.Error)
+	if response.Error != "auth_service_unavailable" {
+		t.Errorf("Expected error 'auth_service_unavailable', got %s", response.Error)
 	}
 }
 
@@ -927,8 +927,8 @@ func TestMessageHandlerOrchestrator_EmailToSub_NoUserReader(t *testing.T) {
 		t.Error("Expected success=false when user reader is nil")
 	}
 
-	if response.Error != "auth service unavailable" {
-		t.Errorf("Expected error 'auth service unavailable', got %s", response.Error)
+	if response.Error != "auth_service_unavailable" {
+		t.Errorf("Expected error 'auth_service_unavailable', got %s", response.Error)
 	}
 }
 
@@ -1830,8 +1830,8 @@ func TestMessageHandlerOrchestrator_GetUserMetadata_NoUserReader(t *testing.T) {
 	if userResponse.Success {
 		t.Errorf("Expected error but got success")
 	}
-	if userResponse.Error != "auth service unavailable" {
-		t.Errorf("Expected 'auth service unavailable' error, got: %s", userResponse.Error)
+	if userResponse.Error != "auth_service_unavailable" {
+		t.Errorf("Expected 'auth_service_unavailable' error, got: %s", userResponse.Error)
 	}
 }
 
@@ -1859,7 +1859,7 @@ func TestMessageHandlerOrchestrator_UnlinkIdentity(t *testing.T) {
 			messageData: validPayload("linkedin", "QhNK44iR6W"),
 			userReader:  &mockUserServiceReader{},
 			validateResult: func(t *testing.T, result []byte) {
-				assertErrorResponse(t, result, "auth service unavailable")
+				assertErrorResponse(t, result, "auth_service_unavailable")
 			},
 		},
 		{
@@ -1867,7 +1867,7 @@ func TestMessageHandlerOrchestrator_UnlinkIdentity(t *testing.T) {
 			messageData:      validPayload("linkedin", "QhNK44iR6W"),
 			identityUnlinker: &mockIdentityLinker{},
 			validateResult: func(t *testing.T, result []byte) {
-				assertErrorResponse(t, result, "auth service unavailable")
+				assertErrorResponse(t, result, "auth_service_unavailable")
 			},
 		},
 		{
@@ -2295,14 +2295,14 @@ func TestMessageHandlerOrchestrator_GetUserEmails(t *testing.T) {
 			messageData:   []byte(`not-json`),
 			mockReader:    &mockUserServiceReader{},
 			expectSuccess: false,
-			expectError:   "failed to unmarshal request",
+			expectError:   "failed_to_unmarshal_request",
 		},
 		{
 			name:          "reader unavailable",
 			messageData:   []byte(`{"user":{"auth_token":"token"}}`),
 			mockReader:    nil,
 			expectSuccess: false,
-			expectError:   "auth service unavailable",
+			expectError:   "auth_service_unavailable",
 		},
 		{
 			name:        "metadata lookup failure",
@@ -2458,14 +2458,14 @@ func TestMessageHandlerOrchestrator_ListIdentities(t *testing.T) {
 			messageData:   []byte(`not-json`),
 			mockReader:    &mockUserServiceReader{},
 			expectSuccess: false,
-			expectError:   "failed to unmarshal request",
+			expectError:   "failed_to_unmarshal_request",
 		},
 		{
 			name:          "reader unavailable",
 			messageData:   []byte(`{"user":{"auth_token":"token"}}`),
 			mockReader:    nil, // handler created without WithUserReaderForMessageHandler
 			expectSuccess: false,
-			expectError:   "auth service unavailable",
+			expectError:   "auth_service_unavailable",
 		},
 		{
 			name:        "metadata lookup failure",
@@ -2851,7 +2851,7 @@ func TestMessageHandlerOrchestrator_SetPrimaryEmail(t *testing.T) {
 			messageData: validPayload(),
 			userReader:  &mockUserServiceReader{},
 			validateResult: func(t *testing.T, result []byte) {
-				assertErrorResponse(t, result, "auth service unavailable")
+				assertErrorResponse(t, result, "auth_service_unavailable")
 			},
 		},
 		{
@@ -2859,7 +2859,7 @@ func TestMessageHandlerOrchestrator_SetPrimaryEmail(t *testing.T) {
 			messageData: validPayload(),
 			userWriter:  &mockUserServiceWriter{},
 			validateResult: func(t *testing.T, result []byte) {
-				assertErrorResponse(t, result, "auth service unavailable")
+				assertErrorResponse(t, result, "auth_service_unavailable")
 			},
 		},
 		{
@@ -3038,7 +3038,7 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 		return out
 	}
 
-	t.Run("alias service unavailable", func(t *testing.T) {
+	t.Run("alias_service_unavailable", func(t *testing.T) {
 		handler := NewMessageHandlerOrchestrator(
 			WithUserReaderForMessageHandler(defaultReader()),
 		)
@@ -3047,12 +3047,12 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
 		reply := parseReply(t, result)
-		if reply["error"] != "alias service unavailable" {
-			t.Errorf("expected alias service unavailable, got %v", reply["error"])
+		if reply["error"] != "alias_service_unavailable" {
+			t.Errorf("expected alias_service_unavailable, got %v", reply["error"])
 		}
 	})
 
-	t.Run("auth service unavailable", func(t *testing.T) {
+	t.Run("auth_service_unavailable", func(t *testing.T) {
 		alias := &mockAliasManager{}
 		handler := NewMessageHandlerOrchestrator(
 			WithAliasManagerForMessageHandler(alias),
@@ -3062,8 +3062,8 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
 		reply := parseReply(t, result)
-		if reply["error"] != "auth service unavailable" {
-			t.Errorf("expected auth service unavailable, got %v", reply["error"])
+		if reply["error"] != "auth_service_unavailable" {
+			t.Errorf("expected auth_service_unavailable, got %v", reply["error"])
 		}
 	})
 
@@ -3078,7 +3078,7 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
 		reply := parseReply(t, result)
-		if reply["error"] != "failed to unmarshal request" {
+		if reply["error"] != "failed_to_unmarshal_request" {
 			t.Errorf("expected unmarshal error, got %v", reply["error"])
 		}
 	})

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -3282,11 +3282,8 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
 		reply := parseReply(t, result)
-		if reply["error"] == "alias_not_available" {
-			t.Errorf("operational error must not be masked as alias_not_available")
-		}
-		if reply["error"] == nil || reply["error"] == "" {
-			t.Errorf("expected propagated lookup error, got %v", reply)
+		if reply["error"] != "search backend unavailable" {
+			t.Errorf("expected propagated lookup error %q, got %v", "search backend unavailable", reply["error"])
 		}
 		if len(alias.calledWith) != 0 {
 			t.Error("AddSystemManagedEmail must not be called when availability lookup fails")

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2978,3 +2978,337 @@ func TestMessageHandlerOrchestrator_SetPrimaryEmail(t *testing.T) {
 		})
 	}
 }
+
+// mockAliasManager is a mock implementation of port.AliasManager for testing.
+type mockAliasManager struct {
+	addSystemManagedEmailFunc func(ctx context.Context, primaryUserID, email string) (string, error)
+	// recorded calls for assertion
+	calledWith []struct{ userID, email string }
+}
+
+func (m *mockAliasManager) AddSystemManagedEmail(ctx context.Context, primaryUserID, email string) (string, error) {
+	m.calledWith = append(m.calledWith, struct{ userID, email string }{primaryUserID, email})
+	if m.addSystemManagedEmailFunc != nil {
+		return m.addSystemManagedEmailFunc(ctx, primaryUserID, email)
+	}
+	return "email|stub123", nil
+}
+
+func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
+	ctx := context.Background()
+
+	const validToken = "valid-jwt-token"
+	const userID = "auth0|user001"
+
+	defaultReader := func() *mockUserServiceReader {
+		return &mockUserServiceReader{
+			metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+				return &model.User{UserID: userID, Sub: userID}, nil
+			},
+			getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{UserID: userID}, nil
+			},
+			searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+				// no match — alias is available
+				return nil, errors.NewNotFound("not found")
+			},
+		}
+	}
+
+	msgFor := func(token, alias string) *mockTransportMessenger {
+		data, _ := json.Marshal(map[string]interface{}{
+			"user":  map[string]string{"auth_token": token},
+			"alias": alias,
+		})
+		return &mockTransportMessenger{data: data}
+	}
+
+	parseReply := func(t *testing.T, result []byte) map[string]interface{} {
+		t.Helper()
+		var out map[string]interface{}
+		if err := json.Unmarshal(result, &out); err != nil {
+			t.Fatalf("failed to parse reply: %v", err)
+		}
+		return out
+	}
+
+	t.Run("alias service unavailable", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "alias service unavailable" {
+			t.Errorf("expected alias service unavailable, got %v", reply["error"])
+		}
+	})
+
+	t.Run("auth service unavailable", func(t *testing.T) {
+		alias := &mockAliasManager{}
+		handler := NewMessageHandlerOrchestrator(
+			WithAliasManagerForMessageHandler(alias),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "auth service unavailable" {
+			t.Errorf("expected auth service unavailable, got %v", reply["error"])
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		msg := &mockTransportMessenger{data: []byte(`{bad json`)}
+		result, err := handler.AddLcomAlias(ctx, msg)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "failed to unmarshal request" {
+			t.Errorf("expected unmarshal error, got %v", reply["error"])
+		}
+	})
+
+	t.Run("missing auth_token", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		data, _ := json.Marshal(map[string]interface{}{"alias": "jdoe"})
+		result, err := handler.AddLcomAlias(ctx, &mockTransportMessenger{data: data})
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "auth_token is required" {
+			t.Errorf("expected auth_token required, got %v", reply["error"])
+		}
+	})
+
+	t.Run("MetadataLookup fails", func(t *testing.T) {
+		reader := &mockUserServiceReader{
+			metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+				return nil, errors.NewValidation("invalid token")
+			},
+		}
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(reader),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] == nil || reply["error"] == "" {
+			t.Errorf("expected error from MetadataLookup, got %v", reply)
+		}
+	})
+
+	t.Run("already_claimed via Identities", func(t *testing.T) {
+		alias := &mockAliasManager{}
+		reader := &mockUserServiceReader{
+			metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+				return &model.User{UserID: userID}, nil
+			},
+			getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{
+					UserID: userID,
+					Identities: []model.Identity{
+						{
+							Connection:    constants.EmailConnection,
+							Email:         "jdoe@linux.com",
+							EmailVerified: true,
+						},
+					},
+				}, nil
+			},
+		}
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(reader),
+			WithAliasManagerForMessageHandler(alias),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "other"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "already_claimed" {
+			t.Errorf("expected already_claimed, got %v", reply["error"])
+		}
+		if len(alias.calledWith) != 0 {
+			t.Error("AddSystemManagedEmail must not be called when already_claimed")
+		}
+	})
+
+	t.Run("already_claimed via AlternateEmails", func(t *testing.T) {
+		alias := &mockAliasManager{}
+		reader := &mockUserServiceReader{
+			metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+				return &model.User{UserID: userID}, nil
+			},
+			getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{
+					UserID: userID,
+					AlternateEmails: []model.Email{
+						{Email: "jdoe@linux.com", Verified: true},
+					},
+				}, nil
+			},
+		}
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(reader),
+			WithAliasManagerForMessageHandler(alias),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "other"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "already_claimed" {
+			t.Errorf("expected already_claimed, got %v", reply["error"])
+		}
+	})
+
+	t.Run("alias_invalid — empty alias", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, ""))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "alias_invalid" {
+			t.Errorf("expected alias_invalid, got %v", reply["error"])
+		}
+	})
+
+	t.Run("alias_invalid — banned char", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "j*doe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "alias_invalid" {
+			t.Errorf("expected alias_invalid, got %v", reply["error"])
+		}
+	})
+
+	t.Run("alias_reserved", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "admin"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "alias_reserved" {
+			t.Errorf("expected alias_reserved, got %v", reply["error"])
+		}
+	})
+
+	t.Run("alias_not_available — email already claimed in Auth0", func(t *testing.T) {
+		alias := &mockAliasManager{}
+		reader := &mockUserServiceReader{
+			metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+				return &model.User{UserID: userID}, nil
+			},
+			getUserFunc: func(ctx context.Context, user *model.User) (*model.User, error) {
+				return &model.User{UserID: userID}, nil
+			},
+			searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+				// Simulate another user owns jdoe@linux.com as primary email.
+				if fmt.Sprintf("%v", user.PrimaryEmail) == "jdoe@linux.com" || criteria == constants.CriteriaTypeAlternateEmail {
+					return &model.User{
+						UserID:       "auth0|otheruser",
+						PrimaryEmail: "jdoe@linux.com",
+					}, nil
+				}
+				return nil, errors.NewNotFound("not found")
+			},
+		}
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(reader),
+			WithAliasManagerForMessageHandler(alias),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "alias_not_available" {
+			t.Errorf("expected alias_not_available, got %v", reply["error"])
+		}
+		if len(alias.calledWith) != 0 {
+			t.Error("AddSystemManagedEmail must not be called when alias not available")
+		}
+	})
+
+	t.Run("AddSystemManagedEmail fails — error propagated", func(t *testing.T) {
+		alias := &mockAliasManager{
+			addSystemManagedEmailFunc: func(ctx context.Context, primaryUserID, email string) (string, error) {
+				return "", errors.NewUnexpected("auth0 create failed", nil)
+			},
+		}
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(alias),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] == nil || reply["error"] == "" {
+			t.Errorf("expected error from AddSystemManagedEmail, got %v", reply)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		alias := &mockAliasManager{}
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(alias),
+		)
+		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+
+		if reply["error"] != nil && reply["error"] != "" {
+			t.Errorf("unexpected error: %v", reply["error"])
+		}
+		if reply["success"] != true {
+			t.Errorf("expected success=true, got %v", reply["success"])
+		}
+		if reply["email"] != "jdoe@linux.com" {
+			t.Errorf("expected email=jdoe@linux.com, got %v", reply["email"])
+		}
+		if len(alias.calledWith) != 1 {
+			t.Fatalf("expected 1 call to AddSystemManagedEmail, got %d", len(alias.calledWith))
+		}
+		if alias.calledWith[0].userID != userID {
+			t.Errorf("expected userID=%s, got %s", userID, alias.calledWith[0].userID)
+		}
+		if alias.calledWith[0].email != "jdoe@linux.com" {
+			t.Errorf("expected email=jdoe@linux.com, got %s", alias.calledWith[0].email)
+		}
+	})
+}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2994,11 +2994,16 @@ func (m *mockAliasManager) AddSystemManagedEmail(ctx context.Context, primaryUse
 	return "email|stub123", nil
 }
 
-func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
+func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 	ctx := context.Background()
 
 	const validToken = "valid-jwt-token"
 	const userID = "auth0|user001"
+	const testDomain = "linux.com"
+
+	// Default allow-list for the suite. Subtests that need a different value
+	// override with t.Setenv themselves.
+	t.Setenv(constants.AllowedAliasDomainsEnvKey, testDomain)
 
 	defaultReader := func() *mockUserServiceReader {
 		return &mockUserServiceReader{
@@ -3017,8 +3022,9 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 
 	msgFor := func(token, alias string) *mockTransportMessenger {
 		data, _ := json.Marshal(map[string]interface{}{
-			"user":  map[string]string{"auth_token": token},
-			"alias": alias,
+			"user":   map[string]string{"auth_token": token},
+			"alias":  alias,
+			"domain": testDomain,
 		})
 		return &mockTransportMessenger{data: data}
 	}
@@ -3036,7 +3042,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 		handler := NewMessageHandlerOrchestrator(
 			WithUserReaderForMessageHandler(defaultReader()),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3051,7 +3057,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 		handler := NewMessageHandlerOrchestrator(
 			WithAliasManagerForMessageHandler(alias),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3067,7 +3073,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithAliasManagerForMessageHandler(&mockAliasManager{}),
 		)
 		msg := &mockTransportMessenger{data: []byte(`{bad json`)}
-		result, err := handler.AddLcomAlias(ctx, msg)
+		result, err := handler.AddAlias(ctx, msg)
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3083,13 +3089,68 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithAliasManagerForMessageHandler(&mockAliasManager{}),
 		)
 		data, _ := json.Marshal(map[string]interface{}{"alias": "jdoe"})
-		result, err := handler.AddLcomAlias(ctx, &mockTransportMessenger{data: data})
+		result, err := handler.AddAlias(ctx, &mockTransportMessenger{data: data})
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
 		reply := parseReply(t, result)
 		if reply["error"] != "auth_token is required" {
 			t.Errorf("expected auth_token required, got %v", reply["error"])
+		}
+	})
+
+	t.Run("domain_not_allowed — missing domain", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		data, _ := json.Marshal(map[string]interface{}{
+			"user":  map[string]string{"auth_token": validToken},
+			"alias": "jdoe",
+		})
+		result, err := handler.AddAlias(ctx, &mockTransportMessenger{data: data})
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "domain_not_allowed" {
+			t.Errorf("expected domain_not_allowed, got %v", reply["error"])
+		}
+	})
+
+	t.Run("domain_not_allowed — domain not in allow-list", func(t *testing.T) {
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		data, _ := json.Marshal(map[string]interface{}{
+			"user":   map[string]string{"auth_token": validToken},
+			"alias":  "jdoe",
+			"domain": "evil.example",
+		})
+		result, err := handler.AddAlias(ctx, &mockTransportMessenger{data: data})
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "domain_not_allowed" {
+			t.Errorf("expected domain_not_allowed, got %v", reply["error"])
+		}
+	})
+
+	t.Run("domain_not_allowed — allow-list env unset disables feature", func(t *testing.T) {
+		t.Setenv(constants.AllowedAliasDomainsEnvKey, "")
+		handler := NewMessageHandlerOrchestrator(
+			WithUserReaderForMessageHandler(defaultReader()),
+			WithAliasManagerForMessageHandler(&mockAliasManager{}),
+		)
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		reply := parseReply(t, result)
+		if reply["error"] != "domain_not_allowed" {
+			t.Errorf("expected domain_not_allowed, got %v", reply["error"])
 		}
 	})
 
@@ -3103,7 +3164,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(reader),
 			WithAliasManagerForMessageHandler(&mockAliasManager{}),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3136,7 +3197,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(reader),
 			WithAliasManagerForMessageHandler(alias),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "other"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "other"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3168,7 +3229,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(reader),
 			WithAliasManagerForMessageHandler(alias),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "other"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "other"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3183,7 +3244,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(defaultReader()),
 			WithAliasManagerForMessageHandler(&mockAliasManager{}),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, ""))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, ""))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3198,7 +3259,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(defaultReader()),
 			WithAliasManagerForMessageHandler(&mockAliasManager{}),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "j*doe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "j*doe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3213,7 +3274,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(defaultReader()),
 			WithAliasManagerForMessageHandler(&mockAliasManager{}),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "admin"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "admin"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3247,7 +3308,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(reader),
 			WithAliasManagerForMessageHandler(alias),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3277,7 +3338,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(reader),
 			WithAliasManagerForMessageHandler(alias),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3300,7 +3361,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(defaultReader()),
 			WithAliasManagerForMessageHandler(alias),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}
@@ -3316,7 +3377,7 @@ func TestMessageHandlerOrchestrator_AddLcomAlias(t *testing.T) {
 			WithUserReaderForMessageHandler(defaultReader()),
 			WithAliasManagerForMessageHandler(alias),
 		)
-		result, err := handler.AddLcomAlias(ctx, msgFor(validToken, "jdoe"))
+		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
 		if err != nil {
 			t.Fatalf("unexpected Go error: %v", err)
 		}

--- a/pkg/constants/global.go
+++ b/pkg/constants/global.go
@@ -76,11 +76,19 @@ const (
 	// Auth0LFXOneClientIDEnvKey is the environment variable key for the LFX One Auth0 client ID
 	Auth0LFXOneClientIDEnvKey = "AUTH0_LFX_ONE_CLIENT_ID"
 
-	// LcomAliasReservedExtraEnvKey is a comma-separated list of additional reserved
-	// alias local parts that should be rejected by add_lcom_alias on top of the
+	// AliasReservedExtraEnvKey is a comma-separated list of additional reserved
+	// alias local parts that should be rejected by add_alias on top of the
 	// built-in list. Useful for ops to lock down branding-sensitive names without
 	// a code change.
-	LcomAliasReservedExtraEnvKey = "AUTH0_LCOM_ALIAS_RESERVED_EXTRA"
+	AliasReservedExtraEnvKey = "AUTH0_ALIAS_RESERVED_EXTRA"
+)
+
+const (
+	// AllowedAliasDomainsEnvKey is a comma-separated list of domains that are
+	// permitted as the suffix for add_alias claims. Empty/unset means the
+	// feature is effectively disabled — every claim will be rejected with
+	// domain_not_allowed. Matching is case-insensitive.
+	AllowedAliasDomainsEnvKey = "ALLOWED_ALIAS_DOMAINS"
 )
 
 const (

--- a/pkg/constants/global.go
+++ b/pkg/constants/global.go
@@ -75,6 +75,12 @@ const (
 	// Auth0 LFX One Client configuration (Regular Web Application — user-facing SSR app)
 	// Auth0LFXOneClientIDEnvKey is the environment variable key for the LFX One Auth0 client ID
 	Auth0LFXOneClientIDEnvKey = "AUTH0_LFX_ONE_CLIENT_ID"
+
+	// LcomAliasReservedExtraEnvKey is a comma-separated list of additional reserved
+	// alias local parts that should be rejected by add_lcom_alias on top of the
+	// built-in list. Useful for ops to lock down branding-sensitive names without
+	// a code change.
+	LcomAliasReservedExtraEnvKey = "AUTH0_LCOM_ALIAS_RESERVED_EXTRA"
 )
 
 const (

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -55,10 +55,11 @@ const (
 	// The subject is of the form: lfx.auth-service.user_emails.set_primary
 	UserEmailSetPrimarySubject = "lfx.auth-service.user_emails.set_primary"
 
-	// UserAddLcomAliasSubject is the subject for claiming an `@linux.com` alias
-	// as a system-managed Auth0 linked identity.
-	// The subject is of the form: lfx.auth-service.add_lcom_alias
-	UserAddLcomAliasSubject = "lfx.auth-service.add_lcom_alias"
+	// UserAddAliasSubject is the subject for claiming an alias (e.g. `@linux.com`)
+	// as a system-managed Auth0 linked identity. The target domain is supplied
+	// in the request and must be present in ALLOWED_ALIAS_DOMAINS.
+	// The subject is of the form: lfx.auth-service.add_alias
+	UserAddAliasSubject = "lfx.auth-service.add_alias"
 )
 
 const (

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -54,6 +54,11 @@ const (
 	// UserEmailSetPrimarySubject is the subject for setting a user's primary email.
 	// The subject is of the form: lfx.auth-service.user_emails.set_primary
 	UserEmailSetPrimarySubject = "lfx.auth-service.user_emails.set_primary"
+
+	// UserAddLcomAliasSubject is the subject for claiming an `@linux.com` alias
+	// as a system-managed Auth0 linked identity.
+	// The subject is of the form: lfx.auth-service.add_lcom_alias
+	UserAddLcomAliasSubject = "lfx.auth-service.add_lcom_alias"
 )
 
 const (


### PR DESCRIPTION
## Summary

- Adds `lfx.auth-service.add_alias` NATS subject so lfx-self-serve can claim a
  verified alias (e.g. `@linux.com`) on behalf of an authenticated user
- Caller supplies the target `domain` per request; the service validates it
  against the `ALLOWED_ALIAS_DOMAINS` env var (comma-separated, case-insensitive).
  Empty/unset env disables the feature (fail-closed → `domain_not_allowed`)
- Creates a passwordless `email`-connection stub user in Auth0
  (`app_metadata.system_managed: true`) and links it to the primary user,
  making the alias visible in `user_emails.read` → `alternate_emails`
- Guards `user_identity.unlink` to reject removal of system-managed
  identities (returns `system_managed_identity` error code)
- Alias validation enforces: 1–64 chars, banned special chars, RFC 5322
  local-part round-trip, 19 built-in reserved names, optional
  `AUTH0_ALIAS_RESERVED_EXTRA` extension
- Per-domain `already_claimed` check (a user may hold one alias per allowed
  domain) and global `alias_not_available` check before linking
- Mock adapter mirrors the unlink guard for parity testing
- Fixes pre-existing broken `golangci-lint` v2 module path in Makefile

Issue: LFXV2-1919

## Pre-deploy checklist

**Auth0 tenant / M2M:**
- [ ] `email` (passwordless) connection enabled on the Auth0 tenant and
      assigned to the M2M application
- [ ] M2M client has scopes: `create:users`, `read:users`, `update:users`,
      `delete:users`

**Env vars (per environment):**
- [ ] `ALLOWED_ALIAS_DOMAINS` configured for the target environment
- [ ] (optional) `AUTH0_ALIAS_RESERVED_EXTRA` set if extra local-parts need
      to be blocked beyond the built-in reserved list

## Test plan

- [ ] `go test ./...` passes (all packages green)
- [ ] With `ALLOWED_ALIAS_DOMAINS=linux.com`, NATS publish
      `lfx.auth-service.add_alias` with valid JWT + `{"alias":"jane.doe","domain":"linux.com"}`
      → reply `{success: true, email: "jane.doe@linux.com"}`
- [ ] Same call with `"domain":"example.com"` → `domain_not_allowed`
- [ ] Same call with `ALLOWED_ALIAS_DOMAINS` unset → `domain_not_allowed`
- [ ] `lfx.auth-service.user_emails.read` with same JWT shows the alias in
      `alternate_emails`
- [ ] Re-claim same alias from a different user → `alias_not_available`
- [ ] Re-claim a second alias on the same domain by the same user →
      `already_claimed`
- [ ] With multiple allowed domains, a second claim on a *different* domain
      by the same user → succeeds
- [ ] `lfx.auth-service.user_identity.unlink` on the linked alias →
      `system_managed_identity` error
- [ ] Reserved alias (e.g. `admin`) → `alias_reserved`
- [ ] Invalid alias (e.g. `j*doe` or `"admin"`) → `alias_invalid`
- [ ] Auth0 dashboard shows stub user with `email_verified: true` and
      `app_metadata.system_managed: true`

🤖 Generated with Claude Code