### PR TITLE
fix(alias): use M2M token for user lookup in add_alias flow

### DIFF
--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -972,7 +972,11 @@ func (m *messageHandlerOrchestrator) AddAlias(ctx context.Context, msg port.Tran
 		return m.errorResponse(errLookup.Error()), nil
 	}
 
-	fullUser, errGetUser := m.userReader.GetUser(ctx, user)
+	// Fetch the canonical record with the service's M2M credentials (read:users),
+	// not the caller's JWT. add_alias only requires update:current_user_identities,
+	// so we must not depend on the caller token also carrying read:current_user.
+	// Passing a UserID-only user (empty Token) routes GetUser to its M2M branch.
+	fullUser, errGetUser := m.userReader.GetUser(ctx, &model.User{UserID: user.UserID})
 	if errGetUser != nil {
 		return m.errorResponse(errGetUser.Error()), nil
 	}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -3394,7 +3394,7 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 		inner := reader.getUserFunc
 		reader.getUserFunc = func(ctx context.Context, user *model.User) (*model.User, error) {
 			getUserCalled = true
-			capturedToken = user.Token   // snapshot before inner can mutate
+			capturedToken = user.Token // snapshot before inner can mutate
 			capturedUserID = user.UserID
 			return inner(ctx, user)
 		}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -3373,8 +3373,19 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		alias := &mockAliasManager{}
+
+		// Capture the model.User passed to GetUser to assert M2M semantics:
+		// Token must be empty so the adapter uses M2M, not the caller's JWT.
+		var getUserArg *model.User
+		reader := defaultReader()
+		inner := reader.getUserFunc
+		reader.getUserFunc = func(ctx context.Context, user *model.User) (*model.User, error) {
+			getUserArg = user
+			return inner(ctx, user)
+		}
+
 		handler := NewMessageHandlerOrchestrator(
-			WithUserReaderForMessageHandler(defaultReader()),
+			WithUserReaderForMessageHandler(reader),
 			WithAliasManagerForMessageHandler(alias),
 		)
 		result, err := handler.AddAlias(ctx, msgFor(validToken, "jdoe"))
@@ -3400,6 +3411,17 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 		}
 		if alias.calledWith[0].email != "jdoe@linux.com" {
 			t.Errorf("expected email=jdoe@linux.com, got %s", alias.calledWith[0].email)
+		}
+		// GetUser must be called with an empty Token so the Auth0 adapter uses the
+		// service's M2M credentials (read:users), not the caller's JWT.
+		if getUserArg == nil {
+			t.Fatal("GetUser was not called")
+		}
+		if getUserArg.Token != "" {
+			t.Errorf("GetUser must be called with empty Token (M2M path); got %q", getUserArg.Token)
+		}
+		if getUserArg.UserID != userID {
+			t.Errorf("GetUser must be called with UserID=%s; got %q", userID, getUserArg.UserID)
 		}
 	})
 }

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -3374,13 +3374,28 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		alias := &mockAliasManager{}
 
-		// Capture the model.User passed to GetUser to assert M2M semantics:
-		// Token must be empty so the adapter uses M2M, not the caller's JWT.
-		var getUserArg *model.User
+		// Override MetadataLookup to return a non-empty Token, simulating a real
+		// caller JWT. This makes the assertion below a genuine regression guard:
+		// if GetUser were called with the MetadataLookup user (pre-fix behaviour),
+		// it would forward "caller-jwt" to the Auth0 adapter — the empty-Token
+		// snapshot below would then fail, catching the regression.
 		reader := defaultReader()
+		reader.metadataLookupFunc = func(_ context.Context, _ string) (*model.User, error) {
+			return &model.User{UserID: userID, Sub: userID, Token: "caller-jwt"}, nil
+		}
+
+		// Snapshot Token and UserID at call time (not via pointer, which the adapter
+		// may mutate after the call). The snapshots are what we assert on.
+		var (
+			capturedToken  string
+			capturedUserID string
+			getUserCalled  bool
+		)
 		inner := reader.getUserFunc
 		reader.getUserFunc = func(ctx context.Context, user *model.User) (*model.User, error) {
-			getUserArg = user
+			getUserCalled = true
+			capturedToken = user.Token   // snapshot before inner can mutate
+			capturedUserID = user.UserID
 			return inner(ctx, user)
 		}
 
@@ -3412,16 +3427,19 @@ func TestMessageHandlerOrchestrator_AddAlias(t *testing.T) {
 		if alias.calledWith[0].email != "jdoe@linux.com" {
 			t.Errorf("expected email=jdoe@linux.com, got %s", alias.calledWith[0].email)
 		}
-		// GetUser must be called with an empty Token so the Auth0 adapter uses the
-		// service's M2M credentials (read:users), not the caller's JWT.
-		if getUserArg == nil {
+		// GetUser must be called with an empty Token so the Auth0 adapter uses
+		// the service's M2M credentials (read:users), not the caller's JWT.
+		// The MetadataLookup override above sets Token="caller-jwt", so if the
+		// pre-fix code path (GetUser(ctx, user)) were used, capturedToken would
+		// be non-empty and this assertion would catch the regression.
+		if !getUserCalled {
 			t.Fatal("GetUser was not called")
 		}
-		if getUserArg.Token != "" {
-			t.Errorf("GetUser must be called with empty Token (M2M path); got %q", getUserArg.Token)
+		if capturedToken != "" {
+			t.Errorf("GetUser must be called with empty Token (M2M path); got %q", capturedToken)
 		}
-		if getUserArg.UserID != userID {
-			t.Errorf("GetUser must be called with UserID=%s; got %q", userID, getUserArg.UserID)
+		if capturedUserID != userID {
+			t.Errorf("GetUser must be called with UserID=%s; got %q", userID, capturedUserID)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `add_alias` failed in **dev** with `Insufficient scope, expected any of: read:users,read:current_user,read:user_idp_tokens`.
- **Root cause:** `MetadataLookup` populates `user.Token` with the caller's JWT, so the subsequent `GetUser` called `GET /api/v2/users/{sub}` with the **caller token** — which requires `read:current_user`. The documented `add_alias` contract only requires `update:current_user_identities`, so a token without `read:current_user` failed before the M2M create/link ever ran.
- **Fix:** pass a `UserID`-only `model.User` (empty `Token`) into `GetUser`, routing it to the existing `user.Token == ""` M2M branch so the lookup uses the service's `read:users` credential.
- **Scope:** the change is confined to `AddAlias`. `GetUser` itself and every other caller (`user_emails.read`, `ListIdentities`, `GetUserMetadata`, link/unlink) are unchanged.

## Test plan

- [x] `make test` — all pass; new assertion verifies `GetUser` is invoked with an empty `Token` (M2M path) and the correct `UserID` in the alias success case
- [x] `make lint` — no new issues (2 pre-existing `errcheck` items in untouched files)
- [x] `make build` — compiles clean
- [ ] Dev: call `lfx.auth-service.add_alias` with a token carrying `update:current_user_identities` but **not** `read:current_user`; confirm it now succeeds and the `"getting M2M token"` debug log appears from `GetUser`

Relates to LFXV2-1919.

🤖 Generated with Claude Code