### PR TITLE
Fix Datadog trace resource names

### DIFF
--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -52,7 +52,9 @@ func handleHTTPServer(ctx context.Context, host string, authEndpoints *authservi
 							if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
 								labeler.Add(semconv.HTTPRoute(routePattern))
 							}
-							trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+							span := trace.SpanFromContext(r.Context())
+							span.SetAttributes(semconv.HTTPRoute(routePattern))
+							span.SetName(r.Method + " " + routePattern)
 						}
 					}
 				}()

--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -10,12 +10,15 @@ import (
 	"sync"
 	"time"
 
-	authservice "github.com/linuxfoundation/lfx-v2-auth-service/gen/auth_service"
-	authserver "github.com/linuxfoundation/lfx-v2-auth-service/gen/http/auth_service/server"
-
+	"github.com/go-chi/chi/v5"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 	"goa.design/clue/debug"
 	goahttp "goa.design/goa/v3/http"
+
+	authservice "github.com/linuxfoundation/lfx-v2-auth-service/gen/auth_service"
+	authserver "github.com/linuxfoundation/lfx-v2-auth-service/gen/http/auth_service/server"
 )
 
 // handleHTTPServer starts the HTTP server for health check endpoints
@@ -32,7 +35,7 @@ func handleHTTPServer(ctx context.Context, host string, authEndpoints *authservi
 
 	// Build the service HTTP request multiplexer and mount debug and profiler
 	// endpoints in debug mode.
-	var mux goahttp.Muxer
+	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
 		if dbg {
@@ -51,6 +54,29 @@ func handleHTTPServer(ctx context.Context, host string, authEndpoints *authservi
 		eh := errorHandler(ctx)
 		authServer = authserver.New(authEndpoints, mux, dec, enc, eh, nil)
 	}
+	// Register route-tagging middleware inside chi's routing chain so that
+	// http.route is set on the OTel span after chi has matched the route pattern.
+	// The span name is also updated here to avoid high-cardinality names from
+	// using raw URL paths (which contain actual path parameter values).
+	// Must be registered before Mount calls per chi convention.
+	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
+	// during routing (inside ServeHTTP), not before.
+	mux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+			rctx := chi.RouteContext(r.Context())
+			if rctx != nil {
+				routePattern := rctx.RoutePattern()
+				if routePattern != "" {
+					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+						labeler.Add(semconv.HTTPRoute(routePattern))
+					}
+					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+				}
+			}
+		})
+	})
+
 	// Configure the mux.
 	authserver.Mount(mux, authServer)
 

--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -38,6 +38,28 @@ func handleHTTPServer(ctx context.Context, host string, authEndpoints *authservi
 	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
+
+		// Register route-tagging middleware before any mounts so chi sees it
+		// for all routes. Reads RoutePattern after next.ServeHTTP because chi
+		// populates the pattern during routing (inside ServeHTTP), not before.
+		mux.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer func() {
+					rctx := chi.RouteContext(r.Context())
+					if rctx != nil {
+						routePattern := rctx.RoutePattern()
+						if routePattern != "" {
+							if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+								labeler.Add(semconv.HTTPRoute(routePattern))
+							}
+							trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+						}
+					}
+				}()
+				next.ServeHTTP(w, r)
+			})
+		})
+
 		if dbg {
 			// Mount pprof handlers for memory profiling under /debug/pprof.
 			debug.MountPprofHandlers(debug.Adapt(mux))
@@ -54,28 +76,6 @@ func handleHTTPServer(ctx context.Context, host string, authEndpoints *authservi
 		eh := errorHandler(ctx)
 		authServer = authserver.New(authEndpoints, mux, dec, enc, eh, nil)
 	}
-	// Register route-tagging middleware inside chi's routing chain so that
-	// http.route is set on the OTel span after chi has matched the route pattern.
-	// The span name is also updated here to avoid high-cardinality names from
-	// using raw URL paths (which contain actual path parameter values).
-	// Must be registered before Mount calls per chi convention.
-	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
-	// during routing (inside ServeHTTP), not before.
-	mux.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-			rctx := chi.RouteContext(r.Context())
-			if rctx != nil {
-				routePattern := rctx.RoutePattern()
-				if routePattern != "" {
-					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
-						labeler.Add(semconv.HTTPRoute(routePattern))
-					}
-					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
-				}
-			}
-		})
-	})
 
 	// Configure the mux.
 	authserver.Mount(mux, authServer)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.25.0
 require (
 	github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f
 	github.com/auth0/go-auth0 v1.28.0
+	github.com/go-chi/chi/v5 v5.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/lestrrat-go/jwx/v2 v2.1.6
@@ -27,6 +28,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.yaml.in/yaml/v2 v2.4.2
 	goa.design/clue v1.2.3
 	goa.design/goa/v3 v3.23.3
@@ -49,7 +51,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-chi/chi/v5 v5.2.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -86,7 +87,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.33.0 // indirect


### PR DESCRIPTION
## Summary

- Add chi route-tagging middleware to set `http.route` on OTel spans after chi matches the route pattern
- Update `trace.SpanFromContext().SetName()` with the matched route pattern so Datadog shows `GET /api/v1/auth/{id}` instead of just `GET`
- Promote `chi/v5` and `otel/trace` from indirect to direct dependencies in `go.mod`

Fixes low-cardinality Datadog trace resource names across the service by reading the chi route pattern post-`ServeHTTP` (the only point at which chi has populated it).

JIRA: [LFXV2-1935](https://linuxfoundation.atlassian.net/browse/LFXV2-1935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1935]: https://linuxfoundation.atlassian.net/browse/LFXV2-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ