### PR TITLE
feat: add topologySpreadConstraints to Helm chart

### DIFF
--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -128,3 +128,7 @@ spec:
               port: web
             failureThreshold: 30
             periodSeconds: 1
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lfx-v2-auth-service/values.yaml
+++ b/charts/lfx-v2-auth-service/values.yaml
@@ -23,6 +23,16 @@ podDisruptionBudget:
   # minAvailable: 1
   # maxUnavailable: 1
 
+# topologySpreadConstraints controls how pods are spread across nodes/zones.
+# Empty by default (no constraints). Example:
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: DoNotSchedule
+#     labelSelector:
+#       matchLabels:
+#         app: lfx-v2-auth-service
+topologySpreadConstraints: []
+
 image:
   repository: ghcr.io/linuxfoundation/lfx-v2-auth-service/server
   # tag is the container image tag (overrides appVersion from Chart.yaml)


### PR DESCRIPTION
## Summary

- Add `topologySpreadConstraints: []` to `values.yaml` (empty default, no-op unless overridden)
- Add conditional `{{- with .Values.topologySpreadConstraints }}` block to `deployment.yaml` at the pod spec level

## Test plan

- [x] `helm lint` passes with no errors
- [x] `helm template` with empty default produces no `topologySpreadConstraints` block
- [x] `helm template` with constraints set renders correctly at pod spec level

## Context

Part of LFXV2-1167: add topology spread constraints to all LFX v2 services so pods spread across nodes and availability zones, preventing a single node drain from taking out all replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)