### PR TITLE
feat(auth): fall back to alternate email in email-to-username/sub lookup

### DIFF
--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -147,9 +147,6 @@ func (m *messageHandlerOrchestrator) searchByEmail(ctx context.Context, criteria
 		user.AlternateEmails = []model.Email{{Email: email}}
 	}
 
-	// SearchUser is used to find “root” user emails, not linked email
-	//
-	// Finding users by alternate emails is NOT available
 	user, err := m.userReader.SearchUser(ctx, user, criteria)
 	if err != nil {
 		return nil, err
@@ -157,6 +154,21 @@ func (m *messageHandlerOrchestrator) searchByEmail(ctx context.Context, criteria
 
 	return user, nil
 
+}
+
+// searchByEmailWithFallback tries primary email first; if not found, retries with alternate email.
+func (m *messageHandlerOrchestrator) searchByEmailWithFallback(ctx context.Context, email string) (*model.User, error) {
+	user, err := m.searchByEmail(ctx, constants.CriteriaTypeEmail, email)
+	if err == nil {
+		return user, nil
+	}
+
+	var notFound errs.NotFound
+	if !errors.As(err, &notFound) {
+		return nil, err
+	}
+
+	return m.searchByEmail(ctx, constants.CriteriaTypeAlternateEmail, email)
 }
 
 // EmailToUsername converts an email to a username
@@ -167,7 +179,7 @@ func (m *messageHandlerOrchestrator) EmailToUsername(ctx context.Context, msg po
 		return m.errorResponse("email is required"), nil
 	}
 
-	user, err := m.searchByEmail(ctx, constants.CriteriaTypeEmail, email)
+	user, err := m.searchByEmailWithFallback(ctx, email)
 	if err != nil {
 		return m.errorResponse(err.Error()), nil
 	}
@@ -182,7 +194,7 @@ func (m *messageHandlerOrchestrator) EmailToSub(ctx context.Context, msg port.Tr
 		return m.errorResponse("email is required"), nil
 	}
 
-	user, err := m.searchByEmail(ctx, constants.CriteriaTypeEmail, email)
+	user, err := m.searchByEmailWithFallback(ctx, email)
 	if err != nil {
 		return m.errorResponse(err.Error()), nil
 	}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -589,6 +589,91 @@ func TestMessageHandlerOrchestrator_EmailToUsername(t *testing.T) {
 			expectError:    false,
 			expectedResult: "test.user.complex",
 		},
+		{
+			name:        "alternate email fallback resolves username",
+			messageData: []byte("testuser+alt@example.com"),
+			userReader: func() *mockUserServiceReader {
+				callCount := 0
+				return &mockUserServiceReader{
+					searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+						callCount++
+						switch callCount {
+						case 1:
+							if criteria != constants.CriteriaTypeEmail {
+								t.Errorf("first call: expected criteria %s, got %s", constants.CriteriaTypeEmail, criteria)
+							}
+							return nil, errors.NewNotFound("user not found")
+						case 2:
+							if criteria != constants.CriteriaTypeAlternateEmail {
+								t.Errorf("second call: expected criteria %s, got %s", constants.CriteriaTypeAlternateEmail, criteria)
+							}
+							return &model.User{
+								UserID:   "auth0|testuser001",
+								Username: "testuser",
+							}, nil
+						default:
+							t.Errorf("SearchUser called more than twice (call %d)", callCount)
+							return nil, errors.NewNotFound("unexpected call")
+						}
+					},
+				}
+			}(),
+			expectError:    false,
+			expectedResult: "testuser",
+		},
+		{
+			name:        "primary email hit does not trigger fallback",
+			messageData: []byte("testuser@example.com"),
+			userReader: func() *mockUserServiceReader {
+				callCount := 0
+				return &mockUserServiceReader{
+					searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+						callCount++
+						if callCount > 1 {
+							t.Errorf("SearchUser called more than once; fallback should not run when primary succeeds")
+						}
+						return &model.User{
+							UserID:   "auth0|testuser001",
+							Username: "testuser",
+						}, nil
+					},
+				}
+			}(),
+			expectError:    false,
+			expectedResult: "testuser",
+		},
+		{
+			name:        "non-not-found error does not trigger fallback",
+			messageData: []byte("testuser@example.com"),
+			userReader: func() *mockUserServiceReader {
+				callCount := 0
+				return &mockUserServiceReader{
+					searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+						callCount++
+						if callCount > 1 {
+							t.Errorf("SearchUser called more than once; fallback should not run on non-not-found error")
+						}
+						return nil, errors.NewUnexpected("database connection failed", nil)
+					},
+				}
+			}(),
+			expectError: true,
+			validateResult: func(t *testing.T, result []byte) {
+				var response struct {
+					Success bool   `json:"success"`
+					Error   string `json:"error"`
+				}
+				if err := json.Unmarshal(result, &response); err != nil {
+					t.Fatalf("Failed to unmarshal error response: %v", err)
+				}
+				if response.Success {
+					t.Error("Expected success=false for unexpected error")
+				}
+				if response.Error != "database connection failed" {
+					t.Errorf("Expected error 'database connection failed', got %s", response.Error)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -856,6 +941,91 @@ func TestMessageHandlerOrchestrator_EmailToSub(t *testing.T) {
 			},
 			expectError:    false,
 			expectedResult: "", // Empty string is a valid response
+		},
+		{
+			name:        "alternate email fallback resolves sub",
+			messageData: []byte("testuser+alt@example.com"),
+			userReader: func() *mockUserServiceReader {
+				callCount := 0
+				return &mockUserServiceReader{
+					searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+						callCount++
+						switch callCount {
+						case 1:
+							if criteria != constants.CriteriaTypeEmail {
+								t.Errorf("first call: expected criteria %s, got %s", constants.CriteriaTypeEmail, criteria)
+							}
+							return nil, errors.NewNotFound("user not found")
+						case 2:
+							if criteria != constants.CriteriaTypeAlternateEmail {
+								t.Errorf("second call: expected criteria %s, got %s", constants.CriteriaTypeAlternateEmail, criteria)
+							}
+							return &model.User{
+								UserID:   "auth0|testuser001",
+								Username: "testuser",
+							}, nil
+						default:
+							t.Errorf("SearchUser called more than twice (call %d)", callCount)
+							return nil, errors.NewNotFound("unexpected call")
+						}
+					},
+				}
+			}(),
+			expectError:    false,
+			expectedResult: "auth0|testuser001",
+		},
+		{
+			name:        "primary email hit does not trigger fallback",
+			messageData: []byte("testuser@example.com"),
+			userReader: func() *mockUserServiceReader {
+				callCount := 0
+				return &mockUserServiceReader{
+					searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+						callCount++
+						if callCount > 1 {
+							t.Errorf("SearchUser called more than once; fallback should not run when primary succeeds")
+						}
+						return &model.User{
+							UserID:   "auth0|testuser001",
+							Username: "testuser",
+						}, nil
+					},
+				}
+			}(),
+			expectError:    false,
+			expectedResult: "auth0|testuser001",
+		},
+		{
+			name:        "non-not-found error does not trigger fallback",
+			messageData: []byte("testuser@example.com"),
+			userReader: func() *mockUserServiceReader {
+				callCount := 0
+				return &mockUserServiceReader{
+					searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+						callCount++
+						if callCount > 1 {
+							t.Errorf("SearchUser called more than once; fallback should not run on non-not-found error")
+						}
+						return nil, errors.NewUnexpected("database connection failed", nil)
+					},
+				}
+			}(),
+			expectError: true,
+			validateResult: func(t *testing.T, result []byte) {
+				var response struct {
+					Success bool   `json:"success"`
+					Error   string `json:"error"`
+				}
+				if err := json.Unmarshal(result, &response); err != nil {
+					t.Fatalf("Failed to unmarshal error response: %v", err)
+				}
+				if response.Success {
+					t.Error("Expected success=false for unexpected error")
+				}
+				if response.Error != "database connection failed" {
+					t.Errorf("Expected error 'database connection failed', got %s", response.Error)
+				}
+			},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- `EmailToUsername` and `EmailToSub` now retry with the alternate-email identity search when no user is found by primary email
- Adds `searchByEmailWithFallback` helper that tries `CriteriaTypeEmail` first, then falls back to `CriteriaTypeAlternateEmail` on not-found
- Reuses the existing `alternateEmailFilter` / `identities.profileData.email` Auth0 query path already used by `checkEmailExists`

Closes LFXV2-2560

🤖 Generated with [Claude Code](https://claude.com/claude-code)