### PR TITLE
feat(impersonation): support optional audience override in token exchange

### DIFF
--- a/internal/domain/port/impersonation.go
+++ b/internal/domain/port/impersonation.go
@@ -8,8 +8,12 @@ import "context"
 // Impersonator performs an Auth0 Custom Token Exchange that swaps the
 // requesting user's LFX V2 access token for a new one representing a
 // different (target) user.
+//
+// audience is optional: when non-empty it overrides the default LFX V2 audience,
+// allowing callers to obtain a token scoped to a different API (e.g. Crowdfunding).
+// An empty string means "use the service's configured default audience".
 type Impersonator interface {
-	ImpersonateUser(ctx context.Context, subjectToken, targetUser string) (string, error)
+	ImpersonateUser(ctx context.Context, subjectToken, targetUser, audience string) (string, error)
 }
 
 // ImpersonationMessageHandler handles NATS impersonation token exchange messages.

--- a/internal/infrastructure/auth0/impersonation.go
+++ b/internal/infrastructure/auth0/impersonation.go
@@ -90,11 +90,21 @@ func NewImpersonationFlow(ctx context.Context, domain string) (port.Impersonator
 }
 
 // ImpersonateUser exchanges subjectToken (a valid LFX V2 access token belonging
-// to an authorized impersonator) for a new LFX V2 access token representing
+// to an authorized impersonator) for a new access token representing
 // targetUser (email or username).
-func (f *impersonationFlow) ImpersonateUser(ctx context.Context, subjectToken, targetUser string) (string, error) {
+//
+// audience is optional: when non-empty it is used as the token exchange audience
+// (e.g. a Crowdfunding API identifier), allowing callers to obtain a CF-scoped
+// token for the target user. When empty, f.lfxV2Audience is used (default behaviour).
+func (f *impersonationFlow) ImpersonateUser(ctx context.Context, subjectToken, targetUser, audience string) (string, error) {
+	effectiveAudience := f.lfxV2Audience
+	if audience != "" {
+		effectiveAudience = audience
+	}
+
 	slog.DebugContext(ctx, "performing impersonation token exchange",
 		"target_user", redaction.RedactEmail(targetUser),
+		"audience", effectiveAudience,
 	)
 
 	tokenEndpoint := "https://" + f.domain + "/oauth/token"
@@ -112,7 +122,7 @@ func (f *impersonationFlow) ImpersonateUser(ctx context.Context, subjectToken, t
 		"client_assertion":      {assertion},
 		"subject_token":         {subjectToken},
 		"subject_token_type":    {f.lfxV2Audience},
-		"audience":              {f.lfxV2Audience},
+		"audience":              {effectiveAudience},
 		"target_user":           {targetUser},
 	}
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -864,6 +864,10 @@ func (m *messageHandlerOrchestrator) SetPrimaryEmail(ctx context.Context, msg po
 type impersonationRequest struct {
 	SubjectToken string `json:"subject_token"`
 	TargetUser   string `json:"target_user"`
+	// Audience is optional. When non-empty, the token exchange targets this Auth0
+	// audience instead of the default LFX V2 audience. Existing callers that omit
+	// this field continue to receive a primary LFX V2-scoped token unchanged.
+	Audience string `json:"audience,omitempty"`
 }
 
 // ImpersonateUser handles an impersonation token exchange request over NATS.
@@ -891,9 +895,10 @@ func (m *messageHandlerOrchestrator) ImpersonateUser(ctx context.Context, msg po
 
 	slog.DebugContext(ctx, "impersonation token exchange requested",
 		"target_user", redaction.RedactEmail(req.TargetUser),
+		"audience", req.Audience,
 	)
 
-	accessToken, err := m.impersonator.ImpersonateUser(ctx, req.SubjectToken, req.TargetUser)
+	accessToken, err := m.impersonator.ImpersonateUser(ctx, req.SubjectToken, req.TargetUser, req.Audience)
 	if err != nil {
 		slog.WarnContext(ctx, "impersonation token exchange failed",
 			"error", err,


### PR DESCRIPTION
## Summary

Add an optional `audience` field to the impersonation token exchange, allowing callers to request a token scoped to a different API (e.g. Crowdfunding) instead of the default LFX V2 audience.

## Changes

- **`internal/domain/port/impersonation.go`** — extend `Impersonator` interface: `ImpersonateUser` gains an `audience string` parameter
- **`internal/infrastructure/auth0/impersonation.go`** — use `audience` when non-empty, otherwise fall back to `f.lfxV2Audience` (existing default behaviour preserved)
- **`internal/service/message_handler.go`** — add `Audience` field (`omitempty`) to `impersonationRequest`; pass it through to `ImpersonateUser`

## Backward Compatibility

Existing NATS callers that omit the `audience` field receive an empty string, which triggers the default-audience fallback — behaviour is unchanged for all current integrations.