### PR TITLE
docs(auth): update email_lookups.md to reflect alternate email fallback

### DIFF
--- a/docs/subjects/email_lookups.md
+++ b/docs/subjects/email_lookups.md
@@ -46,8 +46,7 @@ nats request lfx.auth-service.email_to_username zephyr.stormwind@mythicaltech.io
 ```
 
 **Important Notes:**
-- This service searches for users by their **primary email** only
-- Linked/alternate email addresses are **not** supported for lookup
+- The service first searches by **primary email**; if no user is found, it automatically retries using **alternate (linked) email addresses**
 - The service works with Auth0, Authelia, and mock repositories based on configuration
 
 ---
@@ -94,8 +93,7 @@ nats request lfx.auth-service.email_to_sub zephyr.stormwind@mythicaltech.io
 ```
 
 **Important Notes:**
-- This service searches for users by their **primary email** only
-- Linked/alternate email addresses are **not** supported for lookup
+- The service first searches by **primary email**; if no user is found, it automatically retries using **alternate (linked) email addresses**
 - The service works with Auth0, Authelia, and mock repositories based on configuration
 - The returned subject identifier is the canonical user identifier used throughout the system
 - For Authelia-specific SUB identifier details and how they are populated, see: [`../../internal/infrastructure/authelia/README.md`](../../internal/infrastructure/authelia/README.md)


### PR DESCRIPTION
Updates `docs/subjects/email_lookups.md` to reflect the behavior introduced in #58 (LFXV2-2560): both `email_to_username` and `email_to_sub` now fall back to alternate email search when no user is found by primary email.

Issue: LFXV2-2560