### PR TITLE
[LFXV2-2181] Support LFID username in user_emails.read handler

### DIFF
--- a/docs/subjects/user_emails.md
+++ b/docs/subjects/user_emails.md
@@ -23,11 +23,12 @@ To retrieve user email addresses (both primary and alternate emails), send a NAT
 
 ### Request Fields
 
-- `user.auth_token` (string, required): Identifies the user to read emails for. Despite the name, this field accepts either:
-  - a **JWT token** (Auth0) or **Authelia token**, which is validated before the subject identifier is extracted from the verified claims; or
-  - a **subject identifier** (canonical user ID) — an Auth0 `sub` containing `|` (e.g. `auth0|123456789`) or an Authelia UUID — used directly (no token verification). For Auth0, the service uses its M2M Management API token to read user details once the subject is known.
+- `user.auth_token` (string, required): Identifies the user to read emails for. Despite the name, this field accepts any of the following:
+  - a **JWT token** (Auth0) or **Authelia token**, which is validated before the subject identifier is extracted from the verified claims;
+  - a **subject identifier** (canonical user ID) — an Auth0 `sub` containing `|` (e.g. `auth0|123456789`) or an Authelia UUID — used directly (no token verification); or
+  - an **LFID username** (plain username with no `auth0|` prefix and no `@` character, e.g. `john.doe`) — resolved via username search (no token verification).
 
-> **⚠️ Authorization:** The subject-identifier form performs **no token verification** — any caller able to publish to this subject can read any user's emails by supplying their `sub`/UUID. This operation is therefore intended for **trusted internal services only**; the NATS message bus is not exposed to end users, and the calling service is responsible for authorizing the requesting principal before invoking it. For end-user-initiated requests, pass the JWT/Authelia **token** form so the service verifies the caller from the signed claims.
+> **⚠️ Authorization:** The subject-identifier and LFID-username forms perform **no token verification** — any caller able to publish to this subject can read any user's emails by supplying their `sub`/UUID or LFID username. This operation is therefore intended for **trusted internal services only**; the NATS message bus is not exposed to end users, and the calling service is responsible for authorizing the requesting principal before invoking it. For end-user-initiated requests, pass the JWT/Authelia **token** form so the service verifies the caller from the signed claims.
 
 ### Reply
 
@@ -101,6 +102,9 @@ nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"eyJhbGciO
 
 # Using a subject identifier (Auth0 sub with "|", or an Authelia UUID)
 nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"auth0|123456789"}}'
+
+# Using an LFID username (plain username, no auth0| prefix)
+nats request lfx.auth-service.user_emails.read '{"user":{"auth_token":"john.doe"}}'
 ```
 
 ### Example Response Processing

--- a/docs/subjects/user_emails.md
+++ b/docs/subjects/user_emails.md
@@ -26,7 +26,7 @@ To retrieve user email addresses (both primary and alternate emails), send a NAT
 - `user.auth_token` (string, required): Identifies the user to read emails for. Despite the name, this field accepts any of the following:
   - a **JWT token** (Auth0) or **Authelia token**, which is validated before the subject identifier is extracted from the verified claims;
   - a **subject identifier** (canonical user ID) — an Auth0 `sub` containing `|` (e.g. `auth0|123456789`) or an Authelia UUID — used directly (no token verification); or
-  - an **LFID username** (plain username with no `auth0|` prefix and no `@` character, e.g. `john.doe`) — resolved via username search (no token verification).
+  - an **LFID username** (plain username with no `auth0|` prefix, e.g. `john.doe`) — resolved via username search (no token verification).
 
 > **⚠️ Authorization:** The subject-identifier and LFID-username forms perform **no token verification** — any caller able to publish to this subject can read any user's emails by supplying their `sub`/UUID or LFID username. This operation is therefore intended for **trusted internal services only**; the NATS message bus is not exposed to end users, and the calling service is responsible for authorizing the requesting principal before invoking it. For end-user-initiated requests, pass the JWT/Authelia **token** form so the service verifies the caller from the signed claims.
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -211,11 +211,29 @@ func (m *messageHandlerOrchestrator) UsernameToSub(_ context.Context, msg port.T
 	return []byte(mapUsernameToSub(username)), nil
 }
 
-func (m *messageHandlerOrchestrator) getUserByInput(ctx context.Context, msg port.TransportMessenger) (*model.User, error) {
+// resolveUserFromAuthInput resolves a user from a JWT, Auth0 sub, or LFID username.
+func (m *messageHandlerOrchestrator) resolveUserFromAuthInput(ctx context.Context, input string, requiredScopes ...string) (*model.User, error) {
 	if m.userReader == nil {
 		return nil, errs.NewUnexpected("auth_service_unavailable")
 	}
 
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, errs.NewValidation("input is required")
+	}
+
+	user, err := m.userReader.MetadataLookup(ctx, input, requiredScopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	if user.UserID != "" {
+		return m.userReader.GetUser(ctx, user)
+	}
+	return m.userReader.SearchUser(ctx, user, constants.CriteriaTypeUsername)
+}
+
+func (m *messageHandlerOrchestrator) getUserByInput(ctx context.Context, msg port.TransportMessenger) (*model.User, error) {
 	input := strings.TrimSpace(string(msg.Data()))
 	if input == "" {
 		return nil, errs.NewValidation("input is required")
@@ -225,23 +243,16 @@ func (m *messageHandlerOrchestrator) getUserByInput(ctx context.Context, msg por
 		"input", redaction.Redact(input),
 	)
 
-	user, errMetadataLookup := m.userReader.MetadataLookup(ctx, input)
-	if errMetadataLookup != nil {
+	user, err := m.resolveUserFromAuthInput(ctx, input)
+	if err != nil {
 		slog.ErrorContext(ctx, "error getting user metadata",
-			"error", errMetadataLookup,
+			"error", err,
 			"input", redaction.Redact(input),
 		)
-		return nil, errMetadataLookup
+		return nil, err
 	}
 
-	search := func() (*model.User, error) {
-		if user.UserID != "" {
-			return m.userReader.GetUser(ctx, user)
-		}
-		return m.userReader.SearchUser(ctx, user, constants.CriteriaTypeUsername)
-	}
-
-	return search()
+	return user, nil
 }
 
 // GetUserMetadata retrieves user metadata based on the input strategy
@@ -299,17 +310,9 @@ func (m *messageHandlerOrchestrator) GetUserEmails(ctx context.Context, msg port
 		"input", redaction.Redact(authToken),
 	)
 
-	user, err := m.userReader.MetadataLookup(ctx, authToken)
+	fullUser, err := m.resolveUserFromAuthInput(ctx, authToken)
 	if err != nil {
-		slog.ErrorContext(ctx, "error looking up user for email read",
-			"error", err,
-		)
-		return m.errorResponse(err.Error()), nil
-	}
-
-	fullUser, err := m.userReader.GetUser(ctx, user)
-	if err != nil {
-		slog.ErrorContext(ctx, "error getting user for email read",
+		slog.ErrorContext(ctx, "error resolving user for email read",
 			"error", err,
 		)
 		return m.errorResponse(err.Error()), nil

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -319,6 +319,7 @@ func (m *messageHandlerOrchestrator) GetUserEmails(ctx context.Context, msg port
 	if err != nil {
 		slog.ErrorContext(ctx, "error resolving user for email read",
 			"error", err,
+			"input", redaction.Redact(authToken),
 		)
 		return m.errorResponse(err.Error()), nil
 	}

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -211,7 +211,9 @@ func (m *messageHandlerOrchestrator) UsernameToSub(_ context.Context, msg port.T
 	return []byte(mapUsernameToSub(username)), nil
 }
 
-// resolveUserFromAuthInput resolves a user from a JWT, Auth0 sub, or LFID username.
+// resolveUserFromAuthInput resolves a user from an auth token, subject identifier, or LFID username.
+// Supported inputs follow MetadataLookup: JWT (Auth0 or Authelia), Auth0 sub or Authelia UUID,
+// or a plain LFID username resolved via SearchUser when no UserID is present.
 // Callers that receive a structured JSON payload (e.g. user_emails.read) should
 // extract user.auth_token first; handlers with a raw string body (e.g.
 // user_metadata.read) should use getUserByInput instead.

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -212,7 +212,10 @@ func (m *messageHandlerOrchestrator) UsernameToSub(_ context.Context, msg port.T
 }
 
 // resolveUserFromAuthInput resolves a user from a JWT, Auth0 sub, or LFID username.
-func (m *messageHandlerOrchestrator) resolveUserFromAuthInput(ctx context.Context, input string, requiredScopes ...string) (*model.User, error) {
+// Callers that receive a structured JSON payload (e.g. user_emails.read) should
+// extract user.auth_token first; handlers with a raw string body (e.g.
+// user_metadata.read) should use getUserByInput instead.
+func (m *messageHandlerOrchestrator) resolveUserFromAuthInput(ctx context.Context, input string) (*model.User, error) {
 	if m.userReader == nil {
 		return nil, errs.NewUnexpected("auth_service_unavailable")
 	}
@@ -222,7 +225,7 @@ func (m *messageHandlerOrchestrator) resolveUserFromAuthInput(ctx context.Contex
 		return nil, errs.NewValidation("input is required")
 	}
 
-	user, err := m.userReader.MetadataLookup(ctx, input, requiredScopes...)
+	user, err := m.userReader.MetadataLookup(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -233,6 +236,8 @@ func (m *messageHandlerOrchestrator) resolveUserFromAuthInput(ctx context.Contex
 	return m.userReader.SearchUser(ctx, user, constants.CriteriaTypeUsername)
 }
 
+// getUserByInput resolves a user when the NATS payload is a raw auth input string
+// (no JSON wrapper), as used by user_metadata.read.
 func (m *messageHandlerOrchestrator) getUserByInput(ctx context.Context, msg port.TransportMessenger) (*model.User, error) {
 	input := strings.TrimSpace(string(msg.Data()))
 	if input == "" {

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2373,6 +2373,12 @@ func TestMessageHandlerOrchestrator_GetUserEmails(t *testing.T) {
 				if len(response.Data.AlternateEmails) != 1 {
 					t.Fatalf("expected 1 alternate email, got %d", len(response.Data.AlternateEmails))
 				}
+				if response.Data.AlternateEmails[0].Email != "john.doe@example.com" {
+					t.Errorf("alternate_emails[0].email = %q, want %q", response.Data.AlternateEmails[0].Email, "john.doe@example.com")
+				}
+				if !response.Data.AlternateEmails[0].Verified {
+					t.Error("expected alternate_emails[0].verified = true")
+				}
 			},
 		},
 		{

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2329,6 +2329,53 @@ func TestMessageHandlerOrchestrator_GetUserEmails(t *testing.T) {
 		validateResult func(t *testing.T, result []byte)
 	}{
 		{
+			name:        "returns primary and alternate emails via LFID username",
+			messageData: []byte(`{"user":{"auth_token":"john.doe"}}`),
+			mockReader: &mockUserServiceReader{
+				metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+					if input != "john.doe" {
+						t.Errorf("metadata lookup input = %q, want %q", input, "john.doe")
+					}
+					return &model.User{Username: "john.doe"}, nil
+				},
+				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+					if criteria != constants.CriteriaTypeUsername {
+						t.Errorf("criteria = %q, want %q", criteria, constants.CriteriaTypeUsername)
+					}
+					if user.Username != "john.doe" {
+						t.Errorf("username = %q, want %q", user.Username, "john.doe")
+					}
+					return &model.User{
+						UserID:       "auth0|123",
+						Username:     "john.doe",
+						PrimaryEmail: "john.doe@example.com",
+						Identities: []model.Identity{
+							{Connection: constants.EmailConnection, Email: "john.doe@example.com", EmailVerified: true},
+						},
+					}, nil
+				},
+			},
+			expectSuccess: true,
+			validateResult: func(t *testing.T, result []byte) {
+				var response struct {
+					Success bool `json:"success"`
+					Data    struct {
+						PrimaryEmail    string        `json:"primary_email"`
+						AlternateEmails []model.Email `json:"alternate_emails"`
+					} `json:"data"`
+				}
+				if err := json.Unmarshal(result, &response); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if response.Data.PrimaryEmail != "john.doe@example.com" {
+					t.Errorf("primary_email = %q, want %q", response.Data.PrimaryEmail, "john.doe@example.com")
+				}
+				if len(response.Data.AlternateEmails) != 1 {
+					t.Fatalf("expected 1 alternate email, got %d", len(response.Data.AlternateEmails))
+				}
+			},
+		},
+		{
 			name:        "returns primary and alternate emails",
 			messageData: []byte(`{"user":{"auth_token":"valid-token"}}`),
 			mockReader: &mockUserServiceReader{

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2552,6 +2552,20 @@ func TestMessageHandlerOrchestrator_GetUserEmails(t *testing.T) {
 			expectSuccess: false,
 			expectError:   "user not found",
 		},
+		{
+			name:        "search user failure for LFID username",
+			messageData: []byte(`{"user":{"auth_token":"unknown.user"}}`),
+			mockReader: &mockUserServiceReader{
+				metadataLookupFunc: func(ctx context.Context, input string) (*model.User, error) {
+					return &model.User{Username: "unknown.user"}, nil
+				},
+				searchUserFunc: func(ctx context.Context, user *model.User, criteria string) (*model.User, error) {
+					return nil, errors.NewNotFound("user not found")
+				},
+			},
+			expectSuccess: false,
+			expectError:   "user not found",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add LFID username support to `lfx.auth-service.user_emails.read` by resolving plain usernames via username search (matching existing `user_metadata.read` behavior)
- Extract shared `resolveUserFromAuthInput` helper used by both `GetUserEmails` and `getUserByInput`
- Document LFID username as a valid `user.auth_token` value for internal callers

Closes LFXV2-2181


Made with [Cursor](https://cursor.com)