### PR TITLE
fix: surface reloader annotation on Deployment metadata

### DIFF
--- a/charts/lfx-v2-auth-service/templates/deployment.yaml
+++ b/charts/lfx-v2-auth-service/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/lfx-v2-auth-service/values.yaml
+++ b/charts/lfx-v2-auth-service/values.yaml
@@ -4,6 +4,11 @@
 # replicaCount is the number of replicas for the deployment
 replicaCount: 3
 
+# annotations are additional annotations applied to the Deployment itself.
+# Example:
+#   reloader.stakater.com/auto: "true"
+annotations: {}
+
 # podAnnotations are additional annotations applied to the pod template.
 # Example:
 #   prometheus.io/scrape: "true"


### PR DESCRIPTION
Render .Values.annotations onto the Deployment's top-level metadata so
reloader.stakater.com/auto is actually applied, fixing the "Has Reloader
Annotation" Soundcheck check.