### PR TITLE
ci: standardize MegaLinter, action SHA pinning, and cspell config

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,30 +1,17 @@
 {
   "language": "en",
-  "dictionaries": ["companies", "filetypes", "fullstack", "softwareTerms"],
+  "dictionaries": [
+    "companies",
+    "filetypes",
+    "fullstack",
+    "softwareTerms"
+  ],
   "words": [
     "lfx",
     "lfxv",
     "linuxfoundation"
   ],
-  "flagWords": [
-    "abort: cancel, end, fail, halt, stop, terminate",
-    "abortion: cancelation, ending, failure, halting, stopping, termination",
-    "blackhat: attacker, malicious",
-    "black-hat: attacker, malicious",
-    "whitehat: ethical, security, researcher",
-    "white-hat: ethical, security, researcher",
-    "cripple: disable, degrade, impact",
-    "crippled: disabled, degraded, impacted",
-    "grandfathered: legacy, exempted, preauthorized",
-    "master: controller, primary, main, leader, parent",
-    "slave: agent, replica, secondary, follower, child",
-    "tribe: squad, team, group",
-    "sanity-check: test, verify, validate",
-    "whitelist: allowlist",
-    "white-list: allow-list",
-    "blacklist: denylist",
-    "black-list: deny-list"
-  ],
+  "flagWords": [],
   "ignorePaths": [
     ".cspell.json",
     "CODEOWNERS",

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,36 @@
+{
+  "language": "en",
+  "dictionaries": ["companies", "filetypes", "fullstack", "softwareTerms"],
+  "words": [
+    "lfx",
+    "lfxv",
+    "linuxfoundation"
+  ],
+  "flagWords": [
+    "abort: cancel, end, fail, halt, stop, terminate",
+    "abortion: cancelation, ending, failure, halting, stopping, termination",
+    "blackhat: attacker, malicious",
+    "black-hat: attacker, malicious",
+    "whitehat: ethical, security, researcher",
+    "white-hat: ethical, security, researcher",
+    "cripple: disable, degrade, impact",
+    "crippled: disabled, degraded, impacted",
+    "grandfathered: legacy, exempted, preauthorized",
+    "master: controller, primary, main, leader, parent",
+    "slave: agent, replica, secondary, follower, child",
+    "tribe: squad, team, group",
+    "sanity-check: test, verify, validate",
+    "whitelist: allowlist",
+    "white-list: allow-list",
+    "blacklist: denylist",
+    "black-list: deny-list"
+  ],
+  "ignorePaths": [
+    ".cspell.json",
+    "CODEOWNERS",
+    "LICENSE",
+    "LICENSE-docs",
+    "megalinter-reports",
+    "styles"
+  ]
+}

--- a/.github/workflows/auth-service-build.yml
+++ b/.github/workflows/auth-service-build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Download Dependencies
         run: make deps

--- a/.github/workflows/ko-build-main.yaml
+++ b/.github/workflows/ko-build-main.yaml
@@ -20,11 +20,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
-      - uses: ko-build/setup-ko@v0.8
+      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d  # v0.8
         with:
           version: v0.17.1
       - name: Build and publish auth-service image

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -44,12 +44,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
 
       - name: Setup Ko
-        uses: ko-build/setup-ko@v0.8
+        uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d  # v0.8
         with:
           version: v0.17.1
 
@@ -123,7 +123,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    # Note, this action *cannot* be pinned to a SHA: see the project's
+    # explanation at "Referencing SLSA builders and generators" in their README.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0  # zizmor: ignore[unpinned-uses]
     with:
       image: ${{ needs.release-helm-chart.outputs.image_name }}
       digest: ${{ needs.release-helm-chart.outputs.digest }}

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -25,20 +25,24 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # MegaLinter
       - name: MegaLinter
         id: ml
         # Use the Go flavor.
-        uses: oxsecurity/megalinter/flavors/go@62c799d895af9bcbca5eacfebca29d527f125a57  # 9.1.0
+        uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc  # v9.6.0
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Allow GITHUB_TOKEN for working around rate limits (aquasecurity/trivy#7668).
           REPOSITORY_TRIVY_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN
+          # zizmor's "artipacked" audit needs the GitHub API (to verify
+          # SHA-pinned action tags), which requires GITHUB_TOKEN.
+          ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN
           # container uses GOTOOLCHAIN=local
           GOTOOLCHAIN: auto

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -34,12 +34,13 @@ SPELL_CSPELL_ANALYZE_FILE_NAMES: false
 SPELL_CSPELL_PRE_COMMANDS:
   - command: >-
       cp .cspell.json /tmp/cspell.json.orig &&
-      curl -sf
+      curl -sSf
       https://raw.githubusercontent.com/linuxfoundation/lfx-public-workflows/main/cspell/flagwords.snippet.json
       -o /tmp/flagwords.snippet.json &&
       sed -i -e '/"flagWords": \[\]/{r /tmp/flagwords.snippet.json' -e 'd}' .cspell.json
     cwd: "workspace"
-POST_COMMANDS:
+    continue_if_failed: false
+SPELL_CSPELL_POST_COMMANDS:
   - command: cp /tmp/cspell.json.orig .cspell.json
     cwd: "workspace"
 # Make sure Vale is setup to run with the styles it needs.

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -33,10 +33,14 @@ REPOSITORY_KICS_ARGUMENTS: scan --no-progress --exclude-severities="medium,low,i
 SPELL_CSPELL_ANALYZE_FILE_NAMES: false
 SPELL_CSPELL_PRE_COMMANDS:
   - command: >-
+      cp .cspell.json /tmp/cspell.json.orig &&
       curl -sf
       https://raw.githubusercontent.com/linuxfoundation/lfx-public-workflows/main/cspell/flagwords.snippet.json
       -o /tmp/flagwords.snippet.json &&
       sed -i -e '/"flagWords": \[\]/{r /tmp/flagwords.snippet.json' -e 'd}' .cspell.json
+    cwd: "workspace"
+POST_COMMANDS:
+  - command: cp /tmp/cspell.json.orig .cspell.json
     cwd: "workspace"
 # Make sure Vale is setup to run with the styles it needs.
 SPELL_VALE_PRE_COMMANDS:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -14,10 +14,13 @@ DISABLE_LINTERS:
   # Repository-wide link checking returns mostly false positives (like internal
   # service URLs in templates).
   - SPELL_LYCHEE
-  - SPELL_CSPELL
   # yamllint is sufficient for us.
   - YAML_PRETTIER
 DISABLE_ERRORS_LINTERS:
+  # There's no easy local feedback loop for spelling issues before
+  # pushing, so keep them non-blocking to avoid unnecessary PR cycles
+  # for words that just need adding to the dictionary.
+  - SPELL_CSPELL
   # This may be informative but doesn't need to break the build.
   - COPYPASTE_JSCPD
   # TBD! Need to work through these.

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -31,6 +31,13 @@ YAML_YAMLLINT_CONFIG_FILE: .yamllint
 # yamllint disable-line rule:line-length
 REPOSITORY_KICS_ARGUMENTS: scan --no-progress --exclude-severities="medium,low,info,trace" --exclude-paths="gen/*"
 SPELL_CSPELL_ANALYZE_FILE_NAMES: false
+SPELL_CSPELL_PRE_COMMANDS:
+  - command: >-
+      curl -sf
+      https://raw.githubusercontent.com/linuxfoundation/lfx-public-workflows/main/cspell/flagwords.snippet.json
+      -o /tmp/flagwords.snippet.json &&
+      sed -i -e '/"flagWords": \[\]/{r /tmp/flagwords.snippet.json' -e 'd}' .cspell.json
+    cwd: "workspace"
 # Make sure Vale is setup to run with the styles it needs.
 SPELL_VALE_PRE_COMMANDS:
   - command: mkdir -p styles


### PR DESCRIPTION
## Summary

Applies the MegaLinter/GitHub Actions security baseline standardization from `linuxfoundation/lfx-cli` to this repo, per LFXV2-3338.

- Upgrade MegaLinter go flavor from v9.1.0 to v9.6.0 (SHA-pinned), add `persist-credentials: false` to checkout, pin checkout to v6.0.3.
- Add `ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN` so zizmor's artipacked audit can verify SHA-pinned action tags.
- Move `SPELL_CSPELL` from `DISABLE_LINTERS` to `DISABLE_ERRORS_LINTERS`, and add a baseline `.cspell.json` (dictionaries, `lfx`-specific words, inclusive-language `flagWords` with recommended replacements) so the now-active warnings aren't just noise.
- Fix `auth-service-build.yml`'s `setup-go` step to use `go-version-file: go.mod` instead of a floating `go-version: stable`.
- SHA-pin `actions/checkout`, `actions/setup-go`, and `ko-build/setup-ko` in `ko-build-main.yaml`/`ko-build-tag.yaml` (previously unpinned tag refs). Left the `slsa-github-generator` reusable workflow reference pinned by tag (not SHA), per that project's own documented requirement that it must be referenced by tag for `slsa-verifier` to work.

## Jira

LFXV2-3338

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)